### PR TITLE
Fix pattern-matching example to use "1" on left-hand side

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Using [MF2 syntax], this could be defined as:
 
 match {$count}
 when 0   {You have no new notifications}
-when one {You have one new notification}
+when 1   {You have one new notification}
 when *   {You have {$count} new notifications}
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Using [MF2 syntax], this could be defined as:
 # Note! MF2 syntax is still under development; this may still change
 
 match {$count}
-when 0   {You have no new notifications}
-when 1   {You have one new notification}
-when *   {You have {$count} new notifications}
+when 0 {You have no new notifications}
+when 1 {You have one new notification}
+when * {You have {$count} new notifications}
 ```
 
 Some parts of the full message are explicitly repeated for each case,


### PR DESCRIPTION
If I'm following this example correctly, the left-hand side of the rule here needs to be `1`, not `one`, since the JS code passes an object whose `count` property is "1". If I'm understanding MF2 pattern-matching semantics correctly, the comparison between a selector (or rather, the result of evaluating the selector) and an `nmtoken` key is just a string comparison. So the MF2 code here would evaluate to `"You have 1 new notifications"`, not `"You have one new notification"`, which in turn doesn't match the comment in the JS code.