### PR TITLE
Add bidirectional isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Starting with an empty string `res`, for each MessageValue `mv`:
 The ApplyBidiIsolation abstract operation will take as arguments
 the current bidi isolation strategy and the message and part directions.
 From these it will determine `start` and `end` as sequences of Unicode code points
-which will, if necessary, isolate parts with differing directionalities from each other.
+which will, if necessary, isolate parts from each other.
 With the default "compatibility" strategy, the result matches this TS type:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ though its JavaScript representation is only available to custom functions.
 interface MessageValue {
   type: string;
   locale: string;
-  dir: 'ltr' | 'rtl' | 'auto'
+  dir: 'ltr' | 'rtl' | 'auto';
   source: string;
   options?: { [key: string]: unknown };
   selectKeys?: (keys: string[]) => string[];
@@ -285,10 +285,15 @@ interface MessageValue {
 
 type MessagePart =
   | { type: 'text'; value: string }
+  | {
+      type: 'bidiIsolation';
+      value: '\u2066' | '\u2067' | '\u2068' | '\u2069'; // LRI | RLI | FSI | PDI
+    }
   | ({
       type: string;
       source: string;
       locale?: string;
+      dir?: 'ltr' | 'rtl' | 'auto';
     } & (
       | { value?: unknown }
       | { parts: Array<{ type: string; value: unknown; source?: string }> }
@@ -335,9 +340,9 @@ for the sake of simplicity it may be thought of as having the following resolved
 ```ts
 interface MessageText {
   type: 'text';
-  locale: string;
-  dir: 'ltr' | 'rtl' | 'auto'
   source: string;
+  locale: string;
+  dir: 'ltr' | 'rtl' | 'auto';
   toParts(): [MessageTextPart];
   toString(): string;
 }
@@ -437,9 +442,9 @@ Otherwise, un-annotated values resolve to the following shape:
 ```ts
 interface MessageUnknownValue {
   type: 'unknown';
-  locale: string;
-  dir: 'ltr' | 'rtl' | 'auto'
   source: string;
+  locale: string;
+  dir: 'ltr' | 'rtl' | 'auto';
   toParts(): [MessageUnknownPart];
   toString(): string;
   valueOf(): unknown;
@@ -499,9 +504,9 @@ Returns a value with the following shape:
 ```ts
 interface MessageNumber {
   type: 'number';
-  locale: string;
-  dir: 'ltr' | 'rtl' | 'auto'
   source: string;
+  locale: string;
+  dir: 'ltr' | 'rtl' | 'auto';
   options: Intl.NumberFormatOptions & Intl.PluralRulesOptions;
   selectKeys(keys: string[]): string[];
   toParts(): [MessageNumberPart];
@@ -511,9 +516,9 @@ interface MessageNumber {
 
 interface MessageNumberPart {
   type: 'number';
-  locale?: string;
-  dir: 'ltr' | 'rtl' | 'auto'
   source: string;
+  locale?: string;
+  dir?: 'ltr' | 'rtl' | 'auto';
   parts: Intl.NumberFormatPart[];
 }
 ```
@@ -549,9 +554,9 @@ Returns a value with the following shape:
 ```ts
 interface MessageString {
   type: 'string';
-  locale: string;
-  dir: 'ltr' | 'rtl' | 'auto'
   source: string;
+  locale: string;
+  dir: 'ltr' | 'rtl' | 'auto';
   selectKeys(keys: string[]): [] | [string];
   toParts(): [MessageStringPart];
   toString(): string;
@@ -560,9 +565,9 @@ interface MessageString {
 
 interface MessageStringPart {
   type: 'string';
-  locale?: string;
-  dir: 'ltr' | 'rtl' | 'auto'
   source: string;
+  locale?: string;
+  dir?: 'ltr' | 'rtl' | 'auto';
   value: string;
 }
 ```
@@ -587,7 +592,7 @@ In such a case, a fallback representation is used instead for the value:
 interface MessageFallback {
   type: 'fallback';
   locale: 'und';
-  dir: 'auto'
+  dir: 'auto';
   source: string;
   toParts(): [MessageFallbackPart];
   toString(): string;


### PR DESCRIPTION
This fulfills the spec requirements for [Handling Bidirectional Text](https://github.com/unicode-org/message-format-wg/blob/main/spec/formatting.md#handling-bidirectional-text).

The ApplyBidiIsolation AO will in the spec text need more formal descriptions of how the `"compatibility"` and `"none"` strategies work, but I thought that would be a bit heavy for the README.

We could also define something like a `"best fit"` option to match what's done with locale negotiation, but I left that out as I wasn't sure exactly what it would look like.

CC @aphillips