### PR TITLE
Include missing MessageFunction source argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ to complement or replace the default ones.
 
 ```ts
 type MessageFunction = (
+  source: string,
   locales: string[],
   options: { [key: string]: unknown },
   input?: unknown


### PR DESCRIPTION
When implementing the updated API, I noticed that a `MessageFunction` needs to have the `source` as an argument in order to be able to include it in its `MessageValue` result.