### PR TITLE
Fill out MessageData a bit more, and link to upstream JSON Schema definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,30 @@ The other `interface` descriptions below are intended to represent plain objects
 
 ### MessageData
 
-The `MessageData` interface will be defined by
-the MF2 data model developed by the MF2 working group.
+The `MessageData` interface is defined by the
+[MF2 data model](https://github.com/unicode-org/message-format-wg/tree/main/spec/data-model)
+developed by the Unicode MessageFormat working group.
 It contains a parsed representation of a single message for a particular locale.
 
 ```ts
-interface MessageData {}
+type MessageData = PatternMessage | SelectMessage;
+
+interface PatternMessage {
+  type: 'message';
+  declarations: Declaration[];
+  pattern: Pattern;
+}
+
+interface SelectMessage {
+  type: 'select';
+  declarations: Declaration[];
+  selectors: Expression[];
+  variants: Variant[];
+}
 ```
+
+The full and exact definition of the message data model is given by its
+[JSON Schema definition](https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json).
 
 ### MessageFormat
 


### PR DESCRIPTION
PR #35 added an explicit reference to the MF2 JSON Schema for the message data model definition. We should include that reference also in the readme, and fill out that section a bit more.