### PR TITLE
Wrap MessageFunction source & locales args in an object, adding dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,12 +386,21 @@ to complement or replace the default ones.
 
 ```ts
 type MessageFunction = (
-  source: string,
-  locales: string[],
+  msgCtx: MessageFunctionContext,
   options: { [key: string]: unknown },
   input?: unknown
 ) => MessageValue;
+
+interface MessageFunctionContext {
+  locales: string[];
+  dir: 'ltr' | 'rtl' | 'auto';
+  source: string;
+}
 ```
+
+The `msgCtx` value defines the context in which the expression is being resolved,
+with the `locales` and `dir` of the whole message
+as well as the `source` fallback string representation of the expression.
 
 The `input` and `options` values are constructed as follows:
 


### PR DESCRIPTION
PR #30 added `dir`, but left it out of MessageFunction arguments. This fixes that. The `source` and `locales` are also wrapped with it into a MessageFunctionContext object that's now included as the function's first argument.

This also makes it easier to add new fields to the context object later, should that prove necessary.

CC @aphillips 