### PR TITLE
Use locales as first argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ In code, with the API proposed below, this would be used like this:
 
 ```js
 const source = ... // string source of the message as above
-const mf = new Intl.MessageFormat(source, 'en');
+const mf = new Intl.MessageFormat('en', source);
 const notifications = mf.format({ count: 1 });
 // 'You have 1 new notification'
 ```
@@ -79,11 +79,11 @@ those are of course also supported by the proposed API:
 
 ```js
 // A plain message
-const mf1 = new Intl.MessageFormat('Hello!', 'en');
+const mf1 = new Intl.MessageFormat('en', 'Hello!');
 mf1.format(); // 'Hello!'
 
 // A parametric message, formatted to parts
-const mf2 = new Intl.MessageFormat('Hello {$place}!', 'en');
+const mf2 = new Intl.MessageFormat('en', 'Hello {$place}!');
 const greet = mf2.formatToParts({ place: 'world' });
 /* [
   { type: 'text', value: 'Hello ' },
@@ -144,8 +144,8 @@ Calling the constructor may throw an error if the `source` includes an MF2
 ```ts
 interface MessageFormat {
   new (
+    locales: string | string[] | undefined,
     source: MessageData | string,
-    locales?: string | string[],
     options?: MessageFormatOptions
   ): MessageFormat;
 

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (e.code === 'Escape') {
         sdoBox.deactivate();
       }
-    })
+    }),
   );
 });
 
@@ -99,11 +99,11 @@ function Search(menu) {
 
   this.$searchBox.addEventListener(
     'keydown',
-    debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true })
+    debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }),
   );
   this.$searchBox.addEventListener(
     'keyup',
-    debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true })
+    debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }),
   );
 
   // Perform an initial search if the box is not empty.
@@ -303,7 +303,6 @@ Search.prototype.displayResults = function (results) {
       }
 
       if (text) {
-        // prettier-ignore
         html += `<li class=menu-search-result-${cssClass}><a href="${makeLinkToId(id)}">${text}</a></li>`;
       }
     });
@@ -485,7 +484,7 @@ function findActiveClause(root, path) {
     let marginTop = Math.max(
       0,
       parseInt(clauseStyles['margin-top']),
-      parseInt(getComputedStyle($header)['margin-top'])
+      parseInt(getComputedStyle($header)['margin-top']),
     );
     let marginBottom = Math.max(0, parseInt(clauseStyles['margin-bottom']));
     let crossesMidpoint =
@@ -583,7 +582,6 @@ Menu.prototype.addPinEntry = function (id) {
     } else {
       prefix = '';
     }
-    // prettier-ignore
     text = `${prefix}${entry.titleHTML}`;
   } else {
     text = getKey(entry);
@@ -861,7 +859,9 @@ let referencePane = {
     this.$tableContainer.appendChild(this.$table);
     this.$pane.appendChild(this.$tableContainer);
 
-    menu.$specContainer.appendChild(this.$container);
+    if (menu != null) {
+      menu.$specContainer.appendChild(this.$container);
+    }
   },
 
   activate() {
@@ -930,7 +930,6 @@ let referencePane = {
       e.parentNode.replaceChild(document.createTextNode(e.textContent), e);
     });
 
-    // prettier-ignore
     this.$headerText.innerHTML = `Syntax-Directed Operations for<br><a href="${makeLinkToId(alternativeId)}" class="menu-pane-header-production"><emu-nt>${parentName}</emu-nt> ${colons.outerHTML} </a>`;
     this.$headerText.querySelector('a').append(rhs);
     this.showSDOsBody(sdos, alternativeId);
@@ -1197,13 +1196,16 @@ function doShortcut(e) {
 }
 
 function init() {
+  if (document.getElementById('menu') == null) {
+    return;
+  }
   menu = new Menu();
   let $container = document.getElementById('spec-container');
   $container.addEventListener(
     'mouseover',
     debounce(e => {
       Toolbox.activateIfMouseOver(e);
-    })
+    }),
   );
   document.addEventListener(
     'keydown',
@@ -1214,7 +1216,7 @@ function init() {
         }
         document.getElementById('shortcuts-help').classList.remove('active');
       }
-    })
+    }),
   );
 }
 
@@ -1369,7 +1371,7 @@ window.addEventListener('beforeunload', () => {
 // https://w3c.github.io/csswg-drafts/css-counter-styles/
 
 const lowerLetters = Array.from({ length: 26 }, (_, i) =>
-  String.fromCharCode('a'.charCodeAt(0) + i)
+  String.fromCharCode('a'.charCodeAt(0) + i),
 );
 // Implement the lower-alpha 'alphabetic' algorithm,
 // adjusting for indexing from 0 rather than 1.
@@ -1440,7 +1442,7 @@ const counterByDepth = [];
 function addStepNumberText(
   ol,
   depth = 0,
-  special = [...ol.classList].some(c => c.startsWith('nested-'))
+  special = [...ol.classList].some(c => c.startsWith('nested-')),
 ) {
   let counter = !special && counterByDepth[depth];
   if (!counter) {
@@ -1659,7 +1661,9 @@ body {
   word-wrap: break-word;
   font-size: 18px;
   line-height: 1.5;
-  font-family: IBM Plex Serif, serif;
+  font-family:
+    IBM Plex Serif,
+    serif;
   font-variant-numeric: slashed-zero;
   padding: 0;
   margin: 0;
@@ -1668,6 +1672,8 @@ body {
 
 #spec-container {
   padding: 0 20px;
+  max-width: 80rem;
+  margin: 0 auto;
   flex-grow: 1;
   flex-basis: 66%;
   box-sizing: border-box;
@@ -1713,7 +1719,9 @@ span.e-user-code::before {
   line-height: normal;
   vertical-align: middle;
   text-transform: uppercase;
-  font-family: IBM Plex Sans, sans-serif;
+  font-family:
+    IBM Plex Sans,
+    sans-serif;
   font-weight: 900;
   font-size: x-small;
 }
@@ -1736,7 +1744,10 @@ span.e-user-code::before {
 
 code {
   font-weight: bold;
-  font-family: Comic Code, IBM Plex Mono, monospace;
+  font-family:
+    Comic Code,
+    IBM Plex Mono,
+    monospace;
   white-space: pre;
 }
 
@@ -1801,7 +1812,9 @@ var.referenced6 {
 }
 
 emu-const {
-  font-family: IBM Plex Sans, sans-serif;
+  font-family:
+    IBM Plex Sans,
+    sans-serif;
   font-variant: small-caps;
   text-transform: uppercase;
 }
@@ -1865,16 +1878,17 @@ emu-eqn div:first-child {
 emu-note {
   margin: 1em 0;
   display: flex;
+  gap: 1em;
   flex-direction: row;
   color: inherit;
   border-left: 5px solid #52e052;
   background: #e9fbe9;
   padding: 10px 10px 10px 0;
+  overflow-x: auto;
 }
 
 emu-note > span.note {
-  flex-basis: 100px;
-  min-width: 100px;
+  white-space: nowrap;
   flex-grow: 0;
   flex-shrink: 1;
   text-transform: uppercase;
@@ -2000,7 +2014,9 @@ emu-rhs emu-nt {
 
 emu-t {
   display: inline-block;
-  font-family: IBM Plex Mono, monospace;
+  font-family:
+    IBM Plex Mono,
+    monospace;
   font-weight: bold;
   white-space: nowrap;
   text-indent: 0;
@@ -2035,7 +2051,9 @@ emu-mods {
 emu-params,
 emu-opt {
   margin-right: 1ex;
-  font-family: IBM Plex Mono, monospace;
+  font-family:
+    IBM Plex Mono,
+    monospace;
 }
 
 emu-params,
@@ -2049,7 +2067,9 @@ emu-opt {
 
 emu-gprose {
   font-size: 0.9em;
-  font-family: IBM Plex Sans, sans-serif;
+  font-family:
+    IBM Plex Sans,
+    sans-serif;
 }
 
 emu-production emu-gprose {
@@ -2273,7 +2293,8 @@ emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
 /* Figures and tables */
 figure {
   display: block;
-  margin: 1em 0 3em 0;
+  overflow-x: auto;
+  margin: 1.5em 0;
 }
 figure object {
   display: block;
@@ -2336,7 +2357,7 @@ table.lightweight-table th {
     background-color: rgba(249, 241, 172, 1);
   }
   100% {
-    background-color: rgba(249, 241, 172, 0)
+    background-color: rgba(249, 241, 172, 0);
   }
 }
 #spec-container :target:not(emu-annex, emu-clause, emu-intro, emu-note, body) {
@@ -2909,12 +2930,6 @@ li.menu-search-result-term:before {
   padding-right: 5px;
 }
 
-@media print {
-  #menu-toggle {
-    display: none;
-  }
-}
-
 [normative-optional],
 [deprecated],
 [legacy] {
@@ -2972,7 +2987,230 @@ li.menu-search-result-term:before {
   background-color: #eee;
   box-shadow: inset 0 -1px 0 #ccc;
 }
-</style></head><body><div id="shortcuts-help">
+</style><style>@media print {
+body {
+  font-family: Arial;
+  font-size: 10pt;
+  background: #fff;
+  color: #000;
+}
+
+.title {
+  font-family: Verdana;
+}
+
+p {
+  text-align: justify;
+  text-rendering: optimizeLegibility;
+  text-wrap: pretty;
+  overflow-wrap: break-word;
+  hyphens: auto;
+  orphans: 2;
+  widows: 2;
+}
+
+h1 {
+  text-wrap: balance;
+  line-height: 1.4;
+}
+
+emu-note p,
+emu-table td p {
+  text-align: left;
+  hyphens: manual;
+  overflow: hidden;
+}
+
+emu-table td,
+emu-table th {
+  overflow-wrap: break-word;
+}
+
+emu-table table {
+  table-layout: auto;
+  width: 100%;
+}
+
+emu-figure img {
+  max-width: 100%;
+  height: auto;
+}
+
+#spec-container {
+  max-width: none;
+}
+
+#toc a[href] {
+  background: #fff;
+  padding-right: 0.5em;
+}
+#toc a[href]::after {
+  content: /* leader(dotted) */ target-counter(attr(href), page);
+  float: right;
+  padding-left: 0.5em;
+  background: #fff;
+}
+/* NOTE: hacks because Paged.js doesn't support leader() in content directives */
+#toc ol {
+  overflow-x: hidden;
+}
+#toc ol li:before {
+  float: left;
+  width: 0;
+  white-space: nowrap;
+  content: '. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . '
+    '. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . '
+    '. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .';
+}
+
+/* skip the Introduction since it's before the first emu-clause (and therefore doesn't have a proper page number) */
+#toc > ol > li:first-child {
+  display: none;
+}
+
+#toc,
+#spec-container > emu-intro,
+#spec-container > emu-annex {
+  break-before: recto;
+  break-after: always;
+}
+
+/* according to Ecma guidelines, we're actually not supposed to break before every clause (only the first), but Paged.js fails if we do that */
+/* so instead, just break before any of the clauses that have sub-clauses */
+#spec-container > emu-clause:has(emu-clause:not([example])) {
+  break-before: always;
+}
+
+#spec-container > emu-clause:first-of-type {
+  break-before: recto;
+}
+
+emu-note,
+emu-note p,
+emu-table tr,
+emu-table th,
+emu-table td,
+emu-alg li,
+pre,
+h1 {
+  break-inside: avoid;
+}
+
+emu-table thead,
+h1,
+figcaption,
+emu-alg > ol > li:first-child {
+  break-after: avoid;
+}
+
+emu-grammar + emu-alg,
+figcaption + emu-table,
+figcaption + span[id] + emu-table,
+emu-alg > ol > li:last-child {
+  break-before: avoid;
+}
+
+a[data-print-href]::after {
+  content: ' <' attr(href) '>';
+  color: initial;
+}
+
+emu-table thead {
+  display: table-header-group;
+}
+emu-table tfoot {
+  display: table-footer-group;
+}
+
+@page {
+  size: A4;
+}
+
+@page {
+  @top-center {
+    content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgcAAAAxCAMAAAB5w/qQAAADAFBMVEX////9/f75+vv6/P76+/z9/v/Q3OPz9/v0+fzx9fn8/P/8/P3y9vrp7/Pn8vj///72+f729/oUFBnQ3OXs8fX4+PrW4ebO3eTu9vv+///e6Ozl8Pb6/P/t8vX2egHu9/nz9fno8PPR3OL4/f7o7vLj7PDf5urr8PX09vr5+v73+Pz4+v3r7/Ps9ffc5+zQ2+Dg6e0SFBjk7vT8/Pvr9frj7fL//vzm7/Lg6Ozv8/jk7fDx+fzw+Pzv9/rw9ffr8vjS4OfV4+vv8/bo7PDc5urp7vHt9fju8ffk6/Lh6/HU4OXv8/fd5en6/v/2+/7d5+7j6e3a5OnS3eXS3OPV3eIREhfO3Obv9/3l6+7n6u7M3uQWFxzW4ej1ewHb4+rT3uPi6u/g6vDR3ufZ5+33+/8UExb2+PwWFhnt+Pzs9fvq8/Xp8vTe6e7Q3uXT2+Xb4+fv9fju8/YFBw/8///S2d/Z5evY4uba5e3X5Ozs8/bm7fAGChXr9/zY4+kNDRPP3ubP3eDy8/fi6+71/f7V3ujt8PXN1drU3ebO2uLz+v7e6PDd5ezR3+gREBPY4+gLEhcQERbe6u/R3ObU3N7M3uYKCw/b6PHV2uD6eQL9//7f5uzM0tfU4enM3unm7fLP2N0jJyvg6e/Iz9YyMzfa6O7T3uU9P0LV3+NgYGLi5enQ2+nEzdTxewfS2uIQFB7o8PXY4enQ3+UCBAnz8/ReZWxTVFnZ3uOboKaJj5bzeAb3fALe7PPCw8UpLjXsewbZ6OrP3tzV19no6uvO3OnL3uDQ0NGoqKrI09ri29O/yM/x9fvI3utNUFXxkTTt8vlxcnVWWl8YHCPa29yztbkeICXL3e6ipannhiju7/Dg4eTc29Xj18jfzr2usLLjqm2SmJ7UrYLqmki8w8qEiI25ub2krLR7f4TWomxZYmbooVzov5nU3+7auJbhsoJERkzmexXW2ufo0LjdnF3bjELIys2xvMfafinzhBp0d3rdxq5tbnJmZmnxzKnVwKT8r1+4i2AcU8nxAAAmUUlEQVR42sybe1yTVRjHh8JrhJZuwsxSbGpa2eYiMi8UFZW3mgKbxhANXZQJGYmYA0Y1YyE3BcIIvESKKVCSaVhQXipNKkC6qalJF7O0svv10+8557x7tyllf1B9z/uey7tpn0/nt+f8znNeVYMHPzz4YTeDB4eFhQXhGRsEBXUfTLB+GPX4sHv37njGB7fdpjwHjw6+wE/lzfkc74cBAVSL512PnwfuEbUBAQHn+tA96EwPCepcxLj00osuwuDWi+bMuY3AmDOHcxunN67evd0Ncc45rAa8fpQYOxa9seDRsRgJaMRAlxjHiQi9+QpwM6+v4vRj3AVYI0YCGt6dcVdGBn3zPHDVXdPwaNq0aeNQAL6iWpiT44yNrZ45c+3anNhYZ05scVtZbE6sbmb1ROeWLbE5eBibk5eXs6WNOqC6Gp2y2DMxc2Zs7LD7/1c68Dsd5SHXQXcf/P2DgoL8Bd18uAz04QwfPrxHj549exDog0GDBvXs2TMQXMu5gTNgwIC+ffvS3XeYoFevXrjBEGLUTehdDEYxhixevHg6GPoQY9ZDI0euGbnmITSM8vKl5eXl+qVRKKanTHpTf31UWjpGYHLU5KlRUWlRU6dmFiRQyUyj7yWkZU7NzCwoCCnIDIkPyczMTCDYF6YmZBZkFqgiYwxltWUpGotGayguNmgrK+Oyi9ExZGfvsgCtzmAw6LRSba0EUqSUmJgYnc7gKiszGFwotTpddLZO0uFLOknSrep1QZCPELgK/gv8/p4AxDyOv5tudHOCZfoAefpFAyADziDGgw8+CAWImSfE5I/gDCFuAjcKbgfTiZEjpxAjR17jpj9ARZj05VHlen0Um+n0qDRM3dS0BNYUxFfEx+N2Rjor4itCJk4MQSFm4pftXOtcmxO5NlqKlmIkSaPVaKVkQXR0DApIzknG5zkzVZFSdnFtyoYNGzQ04dlS5d69cbteKa7VSdnZlp2VJUwIOsliKdEQWokqjVZbmwJN6CANLf0XLBY8RnfTgiEBQVd3rgOMPFH58B/owDce+IMgNx7i4FwOEBLohhh6yHBdQAoUIQLdCJXcgAABcUyaNOk+IGuEM3fuPRQkRlA86CUjR4YxjMXjx7NmMdXjFWaBCWDNmjWoqdPfjV6vV7oA9TzBsnnz2HN00REDVSLmW7sBpOiyNRuysyXLO3sr4wyxKRrMscMRB7SSTtLu3ZvscCQjPpRotXEoKSnRKSkaR2KiRWuJs1RWWizoaDW1vXx14CuKsxVC1ysCj0/3B/7+3btDAAFA/sxTI90vhRVw+4Q5CsI2oEO+QHgE9HAzawA7IIOBm7GyP+AWgG7ABm5/0APiAqgZEVTQBIYGzg+MiIgIdTP/rbfeuu6663ATc+/hZQTKxRfPveKKUICK6pvn3zwfLUwGbnIaKqcG82rZuVwyYE14Jzt754aUlOpsaTkmWWMgJC2UYNCV7HUZtBKKw4EpjytZbrEspxigYfFhJ5YV6Ebjgg7wP/jshEBT0aUo/wG/zlB04DHXSiDo5stliAd9+iAYcJfQQwHRAPQEgRxhEFANwDrRd4ACdwlYKYaNGHYP6zOfAGOAFoyRGcoIDx8fDiZw7vBgWa4AnafAPKDXvzyVkZY+m8psPUoamD37qdmz0RD8E+IpGuj1qi82WOhHj+ivk5Zv2A8OHjx4YH9bmUvSwCbgkkoqtRBJycKEqemgIjIRM+8ooaVAknKeTX/sMROudD0+07hyrjtXdbYEeA//9TWBtkZACKCbgNYFmn9fFJNAS8LwPneKWQd88gc9CBSDOACgos4IjrCFNzGYOUA1nYMB7AEzCPAFUwjqMkymXD3cYLpgUXpa+qK0tEWLMtMyF10vqIi/HmWiJ5FeJDoiE1ElOzahSdzESiIiPIpDEx2tyttg0eAXvytOO3NBW9s3x08cOnTq0InjP++vnpkd43TEFBcvKKm06GJDovfs2/rCCy9s/WRPTrzToCHtuGISar8//IKbw68vX7rv3dcY76LlF1Ufbn+O2Ue/5z7eqjx89Tk/iCGoC8OC398JQon9uN37RsQDTzwkcvmlDPgD0Occ0IODDttBcCiMgzupo7iFwNGj4RFwEwMAmgceQFR+4AFyCgJyDPcQc+dezGKFJ0PoGsV6YqvByuIxKIsXrxw/ZOXKleOp3DjeHVSoiEZmzHgUtBPkB6o8h0ajy44rKUlcsPvAz4c+/+jN98C3p478fmA3TKOltrjMsTNv4ROHm1fX2VNBYXvzu2VbVsXt2rSqIOHdk1Y8wnOivnWPKf2Y3WjMV2epbep8my0/H3WWWm3Ob295Cfv1MNUHzVnqLGOW2WizmdWtzfv8MU9BKoWu14H3YhEgc64gAHIICAjyzh34c7oDkT8AaOREAV/yL4dI0CF6n5lzPCCBQCUwA2QJRCbByx9gyGBaQzUOBfqKYIwbh07PiDdYiQjsxwsSBSiCCIYYsNSDAEMF2ATKH5TE6bAFlCorpf0HT3wGFfzY0LCioanpvW8P/balZO/evFXFLstj+06m1meZ1WqrurCosD71p+JYxINNEzus9alqeppks9nUhY1HTbmb7UVWNUG10ao2WyGKJHVSaTvmXKV6+vksqxmfFNEH6tTWd4NZLkHhv4gHPm6QbxQUfPzBZQI4BTGxPALwQMARBmE0AgC4hTPpvr4cJYeASuwT0HoyisBvHIy58EoPwq9kRiEcvfAXX5yQ+yIVwR3Lls0jj4AK5bHOeUogj3NzoQNDWVmtZNG1HTxy6qMff2xqalgBBtZ89cNHB/ZX7q2M3Z6SvrGqvrBOjamj6TW2ptZ3TIZ31G8trLearVbSQRKuwsY96embCwtp8vFlozkJlRGzblMb1Un5jS/hl/jB85AT/o4kK1Ritua37wuSfQJtHv5tHYQp/sAjfRDkmT/A3QeNQCQORNqI5ppm/dpAgmzBfZwbkDnAdC9ZsmTYiCVL3EH9Js7ixe4EwvQpU+AOZD+g0B9ccsnkS/i+L4pIS6N76tSCgoKFBVQtDAkJiefwpEF1NbIGCmsZEznURb6A11KMIJqB7IIqUqtDAkhDMsCa0NDQUDNj2wrQUFPT9Nlv+0sqXbHOlM31tiR1YV19fWp9qtVaqDa3v3S9S3+0sdRqNCZhQbDzdaF9j2npMXsSJjqfggePFEZzUVG+1ZiUVHpyB+mg1GbOLzUb84uKrEbEhaoP3DpgQvjP4oFsEyAJIQ4lFAiZ8HiA6C8HBYoEikegvpBIz0GBYDSu0aNvuQUVoBFnEuO+SZRDIBuAivIHChiMAujBJsAk9LoYZVSvYdT0Yp6AV0gtjKESfuWYcDiB8PArV4bT9oLK0Fmzhs6i6nRmPTR0OgfJSiQsyR84U7QwB9rtB4589sebX80YuGJgQ8OMGTNqtjU0DPzh1DfbKyXD9d+vtlvz1YX2db/8tHl1KqavsL4jN2VChx0qMGe1VzU24gInNy5N2JwFybSvA+1Go9FqbK1CtxFxwZaU/3GA6um3MeZU5RuT1OqsrX5+/wMdBARcwF0CLtkfKGkDGsAe+EMRbntAjtF74UeeYM6dHKQP8PTOOb3FWDz0dAm8J04NIqAa2smHEjhA4KDFM2z5I0LfCCVHMHYcvj/tDRT8Gdbcddc0KlTdLQ4T6OqHTmg/KhkZcsO+SRV9STCtH0aE6uuvtXABcft/JxnUzCAhzKhpamJRoeGHI/tdknMRJhyer65jwb1bthxdByEU2o+lO3Na7IXGosK392x8cuOTALUrJWFzqs1W2vzBjh07Pl6Xb1SbV+/bMWVH29tYNmylHd0e939/h8wHh9uxNth+Cf4v44F7XWBqUPzBGfeNQD5f8M4nBirbRwUWARANlsj09bIHI4A7CtCSITIH5AimA3G8AMRvGjXhlUZYswyWYBlVJmwv+yvo/5qlXmC1wX4B6Z+Stm+OnPhj4ApEAi+a3vutDXnGlnqr0ZraYqqQXCGmrXAKVvtJx7MLmkvVavu6R3JznBVOp5M2rJro9M12s7r0+ecoPfBxe5HZ2v6SCry/zmZU578dfIGfO4kYoHpufVGS0djir+oKziKhrOQQOp1572Y44OcLwxWQRqCsscga3OIG5oAhcge8pqh+I9yBJ7cDlj6YTlAWATM/UsC9wiWTJyckYMJwNBSl16dh3hiZmfEhnIW8iYysiBRs2pTIyeNErgUileAGz1E7cDMdSI62458dem/FCh8Z1NR8dWJ37donTtYbC9VZh69Mvj4zZOnRVjt0sM4VvwBbQKO9JcEp5WnYuYVG46kDP9WrjUa1cTXTQfB6mxo66AMdhIWxRGIAxPFLFtdBl/H3OqAexz8sDJFfJgi4GyYFBeXIkQSB0NADBkHgFQ5IDmjQgr594R/JEShnC2CEOHREQEA+kUBQWEngAAE3MZSQY0CuO5cITPMA+qiJ/uWmXGAymXCD/iimebnU4KKip4QUMn6sKS+fbZqtT1uajq+qvrBI2QbL/i8PffQVLQlewCqeOlAW+V0jFgBb0dZMwyqDIfbo6vokY2HVxoRV0IE6q+VZp+RCTpncpuSjg6ostRk6CPMLCP41n+sggGf1MUfPbe9ohTjU0EEX4ps46FwH1FVMASyCBzx3cK7wimQVcctmEdtHIL9xwJnTG86AW0cyBoovoEaGf+5mrMw4MA30owqL+FUenOc14Fxx1VUZGVjjM/q9QUzDRUSEzqeCiwqSBqPnjyZHQH9lICc0kA4arkXeATrQ4XBp95HP32uCN5gBtm3bRg3rNn37c1vkUdhEm9HcvPnYMVwtrfQrrtqYznRgb8mp0LgsneigKMkGHfj7qfqstyGPQPEA2SRaFJ7e17GulPaT6vVdqYOzjwc077fKMqBpV+JBN6LTM0daK3q4uZMxHCIYHjgocBAIRC0OHJBLnD9pEuvPZ5sGRAjaPtzH+g/IDMDd95lnnhn2DFXD7plL7YWjriSwJRDwI4dliAboYOzLi+Fe0J/w+dNixFrVF5rsXdmxB458BGs4kAEdoCawUPzw5e68o+2kAyM2hvX12B4iZ5Rka9yYu4r8QeqxZx3akjgt7T61WovDRwdqK3SAPq0LRtIB84QfbP11nbUUOUfIwLgeMhH86/4ACH/QeeYIyC8giNbLGxCByisnwhsgdUDAJJIrQCXbg5vE+QJsgTf8/QNyB9wRAF71j5rMwYB37hUsVDII1MIebBLWgIhz5DFgAgTexoBwlDBwUgQd4KWD6oOfvVkzsGFbw+k6OLG74vv20iSbsQ65IqMVOSKkjNSpVa+bVjWnwh8878xjZw3aM+kg38b9gX/w+ixZB+e++tO69vwsm8g5mrtIB8ArhazQ+brA9w2ovNRwmioQBrwY3kPB7Q0efFB0kU4UsKNGBd73eCmJMgKcMWcAuwf3/p80w72kCdCqz5h3jfCWoLy8PyQkbgXko/TgEkGUjMopGbId1QdPvQl3sO20eLDth+O7r/++tdRms9apMXVF+AXTyUBp1euLFjyPHWRpy7Nrtd46sCk6sLn9wfp8roMLgl9otJZiPbChUNqxaH03P1WX07k/wBrFefzxx8kfUBcN3WKBAN6p54t8mcMR/gDrAlb7O3vzHAKGqPhTH3qIWyC7AwG67l5oKN4eiGB+wXP3f/fdd2dkZAijcOF5510XKAObEIjMA0ooq3AjLQHmI5cArsX+hjY581GuvRZHDipntM7lMEAHNZh1rAyebFsx8NvjLB7Y1HV1ZrO90F5YaLdn2e2pjRtJB0b4gwIcV8rrgjYy95inDoqMiAfUJR3AHwQHBB+2Gm3wF0Xq1tUtJ83qJPP6bqou5Cz2jdRlI8y5GzkWeCIigz8lkQBvLgPynBJ4V42/iDQcrRe0eiA6yHi9ljQM7dx7ZNgBg/dRA72bRLVY2Ye6l30cNYTLewn36eGEWXeMnDdrAgoYT8WHO9bMu2PNHXiPie07HpoyBTqIsVRK0EHTDOSSvXWApeLbb9oq9qwuzTfW1f0qnzB3fNrx6QuuRTHNpVZzaktCfKRLq5WYDpIl0+ZCc9KZdWDN/2WQ6qXV6JizWqvWH94e3JHa1Tr4h/6ATfyZ0gi4FYQzoJrjMdG3eLBEBsaAUN4/IHyyBzAIQD5doIreTyRPEBXFwjlsAga+DiE+REH0qycCOl7I8UQ5Tli+fHl0NPb4iYkaGkoSvVyqmihJOysTD3z20XtNAxt84kFTQ8Oh3SnOJ6vqi6x19sPj9MtedGOJZ/4gtWWL05WMv0wHXJsisS50pgMz9o2DPq2nY6eTHd9hkvp8mtXlOsD9d/sFRQfyZsFnh+DLZYzT/YFHNnE03QK3LujHL15HUjKKQh50j5IZspIQ+YNZQ8kcKG8KzAIjZfqbRO7QZMLvmicPcpcBuIXZXrzsBdIGejdp+FgVIll2WpJ3n/gcWWX4RC+amr463mbJWdVcb7Qin/hQSPauuF0ulyvZFRdnqVhFR4elLffmuHQGDb3GDGWtNW3uZF2wqYuQT9zRTIfQz29nq3KfT0u7WAfcJ3aqg8cZ3vkDgsTgm20mxHPlXzGIRpgD8Y8TaNSb+JN48451KYrj+LXuH2a8a9XWxB7PfEJIEYRY8apFK2rkaYiRiD2qkodnvLSKGFF7z2eFWHmUqB2e2ju2Z8Ve4fs75/Sed2sGLz5tz7i3/ev8eu73/Ea1fpAFhOiEGpgKhCCI+g9YBzkgaMqqC/BBw/MIdE2gX+xP1LcU5MCBQOBSV864WOoT+gw/7Y9MBT6iy7AD5BVpZ1/QhhBjBog9v3xRzN5nyr2tFDHa9G5y25kr8Jo2bc9Cuz3ZesLvx8Fh7qK0ziPT0uDyHN9DUwdu/6E+cKd+yLl2uR/RyMMKoP0gNVvtIAf42X4wn49yccjDLIZMCxjJSRj9B5SkaAwzyBAD7yQTQbt2LbijgFMmC5UrQyMIZQA2M0qVasgphVFdKINvaSDCDJSOQDIB24cMPyzt1as39o6lKH7AzgFHJF5RlqIeYmkvFp0AuK0k49QXb50bzrx18u2GeWWNvLl+ZfUE++O7cB25EVJ6em/nXc6yKUE1+cHQVGfcnO2v198+KkhZOPzHzwXoRNgBDhvn9m67SBx8l63Phd/yH+BxIBefCwQQKxDQ6GUM1DBpgHcUXR5AHxgVAvkRovEF8h4AgzwYw+gu0xOJ2lBwBDb3BaASaN9z+gLEF2JI474D1hohiaCa8VITV7rwWukaRK9BqkYvTbWasYOrVqptYDA78A7eePnTrZMn38bYwbwLj8LpLsfjIye2QuJjIXFc2ASgFabP1nrvGkoZSmPPLImy6mjfzg/G+uv80A4KH1zlcdaxRUPPS5Ky0Q5+y49EqkA8DZg+gB0Y+Db2JPcDGXmM8R9IhDygFmTZAopwosmrBQimDBiL6uqQ01CGGRlt6M8OSxmIP/XAmTzQgMDjQHSsImFFp4GdBq5YUWuFwKgP+nKQ7ToSdxijkLuM/INAQNWss8KfkYdyYV5ZxBTgN8AREseHL5nh5xEULky/OxYWEAds/iTEjupsvTFCU5GlNHYTnhee1KRU+BRsNuSljey0HWeArScmIheR7CCJ/AcJCYUKr0lNcnveFb34EWcMGzLT6hAkGZOEH6lQLPgVEHcSCv1rUxBJiUIDiBmNYskrEc4DGpTu0EG4DtAQ4hTJ9IGsXjAAoRCbqBgbX2jCrjUxehKIphwMjkFeHKMSBShNSyNjsLucBLkMzH9N0KAph241FTDfBOZ0CXagqgHYweWrN5Gk+nb3hv2Qi3Ak7n924ULmi/C648dnL+7S8/TYoT43fInkUEQOku9GZ/yq0w0fPAjIQYSfOQ4rS3YwfbvPw54L+RTyJ8b5yY9UDyHmVDf5D+rthLbEl21xHLcn6WPRn9iBkp12YOKLLLxENDHUNaHJKR4YRnHA0pJoLdl6io1BniKlVgDIWNPXqbw8Q7QjWgidwJyLhm4AkL4EaqQvgcUVWBgSroEGDRc1liAhid3nHeUjS9o20GnLYaPoTEm2xpsDKF47EH5///r1txvA/v34IE/10ZXwgXX2oDd91ojB95Yg92yO3+fB2+fbuqslHjOu4ffODB3r83hsHr/fBw8T3w9stjkntim58iiv9qX642AHUGvYD5CNdro88tKG+uu4kZLG8NvciC+Y8piUb+FWYDKZ2CQb7AAexKzHAXpEVP+eM7mojjgm4k3I0kbBRE4Zjr7zw3fMkbqAMAQXuPtgLTWgEtE+liEcZCYWGwEouIAPYyHvmukg1WAQgTiDytEmMKhmQeNghkIUhlpccXlRwOIIBgcfCL/IvPnw5UnOreuPrl6aNWzwuoA5PT09Pm3k+l07lp9x2nzOTWDojVpaSqLZVStj+z44Gp22OnQVeaqjpm/3ON1+7AemfNgP3E7nvr0oUDAVXhN35oz79EQkLN9bfgaRCo7bCb9y7jw5TD+ETAHMV7LBDsh1QPEEjjHYJPcBI9UAhRiACCyTVQiMorEFwSpZiggm4VxQOUoN3bHEukUMaEb80+E5ZGlJY0C3xt16RWEVz+QxqDS9Ek84iFKJIYMGSFLBBw2GgA8FNJHD8Z0p87Uz7ABxZ0cwYseOcOXqoyf37z8E159kXj0QOB4MaVPivTAEb/LjkZNvZ5w/v5M4v/OouVkzNTHe1Xnx6/M059xFHcvtjDsZGa9ymkw5lIt3Mu7cuVPDlAOlIa9wNeNAbhSzbDt851pW9ubLlefHZgD44E/IUejn+wHIq9exfCMHov4DmdIs9AHvQEciV66qgtI8K4HnGTAvMxojTaQqoE4CtwAhXASy1IBGJaIwdwFFoy2nTtGcUgqImjXRSGpyRgN0rQUYGq4DuieuKFtgBnAlHY+EAnPPkim8z7x582bm58PpXjO0QYp1cOIgB7xHickjeo4vltYzrdiC8T2aD+qDrSZFTUns0SnrMUYbnDLahOMByJ31X4nsE06efDQSU6O3B5gMZN+RQdoB9WLN83CMsSThMJKqgTWAzVjySVVOdQ72CeMa5weNOIjrcEnA0g5aE/UtWF1wymIAKcwEUpnLlEEDYABIQ6iLwAJVM5QqKCj1d9TlYKTMKO71WtUJoUgkZE9p9nwKFOOVK1fCZ72HDqVHgg5zfPK6UGj2Fq9ro9VsdXWxdlHNiwdRdWtKH7ypwhFH1ECi1QqDQfnzYgs97Ol/iFUohH9kbvREPfw5lXpKjty4odcqYEBZasr/sQNe455LoIcYGLSwMpBU2ABzHhCsvlGKA4H+OOAqoTJEgg7LRm2FltO4QRsCWq2XBHu/iDSUpE8lufe3By2HM8bztvn3WMhp9iOQf8Bb6rcAlp+omZlnIRQJIiPhOcqczShunTss/tChQ0GHN91rXxeJzPZ6UficBUgL0RAaED3qnU1C7CcQhRIUmtAUHVa9Hk0SeJvAR/UwQEv3MCzEQJcDU/4l2ApWFab0t3Ygr8l4I0SCkdyE8V8u1aLBKqqQK7E8QEoSWpmVImEmIZKUa3B4ukGBCmgqMFnQhoOBoCJylUWyMmWtLm3LAgokAmohmsAzDng3cpQEdoHWCKyCWgnGurVkNRzlcSigmc2Jqhawz3Y4Zm3cqIWCQbuKgneH4/lGSANHJBLB3Kz+0g40ZgcdTFg7/qY1ppXFajPLoDkuAozRE+J7GOBLAN+kKW4jpZUmeGFGC/jPdaKMO0vy8dLG0gb4wyBGHwj/AatkkFUN0AcyDVG6EDCPoQmd5Us0KkFYCLT1LZaa9REkkId8jIQwgCxAHKF+NIDwtbZza20iiOL4rrkYjVFDq3U1xct6bzXi/V6p1mtHqwapIlZBBEUbZUKhoniJrhXBh0QIcdHgvpQaioqQZ+uF4Itvgn4LH/wA/s/MZDdZFcXLz905M7vbvMxJ5r9nzoxnUcGTMwRXcLqsloh7ZxVoSmbU2svowzyw3hmvBMn+UUwYHmnBK2IynHv06EHLvNH+ptyXQv7Vq7cPHr05EoafoNsb+l3RQig/ONKUmcsM8W2eUtSBFpyyNkRWJ9Cr1LVFGOp/nKLEDwEeoFNSVBkjRhR3dTyg6UaIvrn/yQ9Q94gC1c+q64MNqAtLfoRKSmjoc7UWWiGjPigICieIFMUPuzpqC52bUbZSdVCBKukAzDLADWiTC3cWs6MDZzOoT13wQg2LlEGc0r96EtAyKZwu2q1crik8D0GEcBIzx2/ftuT6m7DC6dHTXH/hS3/y1VusiIePhJ8+DQOfH/jB7wb8YG2gyLnBNYau1JhYtgaj4eVPD0AD6EUtgbx1o2gwjZzDiIY4T3BN4zrHOyY38ChDjIdxXajKtbpmCF8qGvhAwZ+PC9/nH4Coj6AKHPiJK7yYkScOlCE6ZfxArFy5TcPBIkmXQooEGUOgxQw0v9Ar6MFBIPegThWkZXqiSD9Ip3F4DCimS+QiRyrAIeQgQLbtlfQdqiN8mO654AryUK5jP5swRMIoFMDbY4/e9Cfz1x98/Pg0WcAWSJRkNA/8rh/Q70GRme0RPqE5HuI3Os3m2+03umL7x8egkkyzc1H7hoTBFrefMfiNZgZv6WznLBKLdTa3b020zuEhdmP7686AwdtinYwFX8Z1nY9vnmNEi+M+xeE7gn+mDxR+TwgKGuaZCKUPYKQ4ICAMfF5BoQNSBjfoFPrAv8y5KwakO8R+FFvqXeAlpcyEWKRqz3qZqLqjES+JgJCaQAqDq2TrZCNqHs9BwxVtGJsfgKZrOVKLb48dyYXz+VfhN2+OQBq0PDgifi6ScBOMDR6uH8yTiAqayg9arXWJtN19+nQlE0lZtmVnPnTYlmW3birYjp3aYo44C6dmK4VIgt8Ys9q1+RZu2ql9+cp+dnTMtu3uSUarbV3kMfso56xipxJ68dPYa82Q/Om+OLA+P/DaiigRCq2SwEUIN509KPRBlLZJ8khQq02BGkWcJSqCEAGeaKgNETjo9A0VVNsiJwgUWNmICx71N+svLPOxejVkADSHogPIFhmKPyAHQYIrWip//dhbxBNzTbmnuSaoA/KD/Lynb7Br2rFjD2gDLeEHeKlw6f+VH1xydrPn5epunreymz+MVp9tnrq7/HjTB3OTNbrlnrM7e69sdbDppbuMj9h2nm/avK6amhG5ZKXNZjszIZK2e3iz8349W/S112ARy6lGpvBP70b+zg/A7/kB0KUTuKJAGOUHEBBkXFHgIjdFOFO//lkaadWMkCwmIeCDOQaUYl7ykkxNwCXMOFCYx2PwmdIL52hYx5ZK3kQlSglsF1AtpQeoFIumqYUaESPUvGZsnbxOt7RtF1pacPw1R4hrQ8lYCKpu0FnAjleHDpupkmmwVGk8D/U4syLj+Xjrxd0F1SeBE1b11t1tQ3d5dqgwUl1tMtNOM2OwNGyO2PN5aGLGYq3Voeqmc+UVzDxZ3WOt4dnZ1fWM4dOhGv5SJDZ2uaqo77s3ueBf5qhw0068b3JtmQoQr4r++eV2ojE/cTsQppegkDHtnriiF+cKxA0UKwQqbtwtUDkIV9X6xquC+wMCfwrCLcUdoPZBwGXQhx0TCWr19eHA/okvLrTQjmcXmi7g8EzTL0yLRD6Oj8hdw7+WQ8kY06N8q/PYPNy00uocsOAHhVJEY5fLVqkQjVvlPqePTT2RPGVNPl7K8lnV5gnOVc5Ne8AITbIG2iqlD/CDih0ZdNYMPexwbrJsaTh7aCDCd5bXc4b3in+Qo9pAVOLLRPH7Qd08k+cHKAiVg3IReNuoqk0OWoHSBWpjNC9j1V3hvObyAsXNFfAICAJwcoWXh+jNIcyk1BSkpHii4CC4L6AavILK588Hjh9/ThxXNOSy3rrlNiXatqbwn6DEojs8yOYQ/CChh7RWZyMbHtpUSSctpgUKVlwL9paX9xwNnClZfc5yM9JdupsZ2Gvd5QPly132UJbHrQEtNMFKL/1sbWChUMqKLCov22M9wQCxwRlet9dq5oPOeoOHaIz/65z1BnQ1EngawFvHIpfBo1aPGubliaIed2MDqrmPSWg4UG+OQIkBNdijcLc+UKvbOgDiBsr8nFke/ou/j9aXEuM70pRSqXn9njlMJuU3/a5J0l8lw3hcXOw73I8XzkN9pRhHOLnT6WGVUrbVdkaZESpY03S9t7qFaaFp1jBLV5dFK1Zbl+WU2KSqlR8rOYu0xVZFmzLBGm7rKi/k2mI7r7c657IZx+7VUk6qVPiazp6zeqAPpB/8nSeEfghthuK6gFzCEFQB58bVDDI4VPOBqdKgkL8QwJWEVDRuoaQqQD2+RVBTe6iRwUGsBnLyAaqvA8BJal6x+gcO4fqA2/bx86vavEwygyPpN8lfmEImg32ZR+v+ahT77yZLXWwK/KDcw/KlrFkoZzB/k7fj+tre8nD687RpdopvL3dHP1tnAqn3Fntdnrs4Pt9JB8fZBU3fag+zcRk7PTJmd2nt5Rib+97pPWOnx8/eWbDnnCuXKp/j2qq/d4RQAypzPRhA9/vS0XzCQFVlr9a+2bBkcG4ljYeJBYEYEWSSySBOd7JZTDPLNEWhEDAsCGqR5BWEMiefUJ7peRFNoHVqwkqlsKO2adJBwX3JVQENDhgQkJ4A3DGhbnRA6UdbOLKQFkjAUOEzhDL+O91gpLvu4sMDD+9h7nswiiDhnEKnsfDEXf6pksY808jn+Nq1XflUauxlW7qbnUkvDBxNm1p7ZWD/63S2qCdOpuPBzz2aPg53jC3dpbFKq6ndKGzlZqXSfqnQyTnbPjZhUqpSGPukQcoX/40fqHllGAA3UPwk86A+llQfIJQeQX5A+l/pA9rvQCAmFeAAVMQAeh9usN2jV4KaF0i6SWEDiEV3qaJA1u7JjBRKLxCKQOpEKRTvq7TVq8ePQzQOC10IZHCpQUIq+lw0SHXAfmyAa/x3PJjbzqJhYIqAmbqGhqGbpoHOWIKpgqBpngniRTzLedacqGfZRGbuLwayTNPw1zqe1EL4AGMiy2aDQZNH28z9LBEwGWvjJhwhkMBjgaCKAfydI4QkSEJppDEpjYhKlGcEJW1t7mYH3hxCRFLzCheVr7qPdsnxwgQia5AeraUU4vZOIP5bBVmQpf2SXVy98DOR4FZVe6645tcORENL3PsGebg/fq/Wa04AAAAASUVORK5CYII=);
+  }
+}
+@page :first {
+  @top-center {
+    content: none;
+  }
+}
+
+:root {
+  --page-number-style: decimal;
+}
+
+#toc {
+  page: toc;
+}
+@page toc {
+  --page-number-style: lower-roman;
+}
+emu-intro {
+  page: intro;
+}
+@page intro {
+  --page-number-style: lower-roman;
+}
+
+#toc {
+  counter-reset: page 1;
+}
+#spec-container > emu-clause:first-of-type {
+  counter-reset: page 1;
+}
+
+@page :left {
+  @bottom-left {
+    content: counter(page, var(--page-number-style));
+  }
+}
+@page :right {
+  @bottom-right {
+    content: counter(page, var(--page-number-style));
+  }
+}
+
+@page :first {
+  @bottom-left {
+    content: '';
+  }
+  @bottom-right {
+    content: '';
+  }
+}
+
+}</style><style>
+    @media print {
+      @page :left {
+        @bottom-right {
+          content: '© Ecma International 2024';
+        }
+      }
+      @page :right {
+        @bottom-left {
+          content: '© Ecma International 2024';
+        }
+      }
+      @page :first {
+        @bottom-left {
+          content: '';
+        }
+        @bottom-right {
+          content: '';
+        }
+      }
+      @page :blank {
+        @bottom-left {
+          content: '';
+        }
+        @bottom-right {
+          content: '';
+        }
+      }
+    }
+    </style></head><body><div id="shortcuts-help">
 <ul>
   <li><span>Toggle shortcuts help</span><code>?</code></li>
   <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
@@ -2980,7 +3218,7 @@ li.menu-search-result-term:before {
   <li><span>Jump to search box</span><code>/</code></li>
   <li><span>Toggle pinning of the current clause</span><code>p</code></li>
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
-</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
+</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
     </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins<button class="unpin-all">clear</button></div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">+</span><a href="#messageformat-objects" title="MessageFormat Objects"><span class="secnum">1</span> MessageFormat Objects</a><ol class="toc"><li><span class="item-toggle">+</span><a href="#sec-intl-messageformat-constructor" title="The Intl.MessageFormat Constructor"><span class="secnum">1.1</span> The Intl.MessageFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat" title="Intl.MessageFormat ( locales, source [ , options ] )"><span class="secnum">1.1.1</span> Intl.MessageFormat ( <var>locales</var>, <var>source</var> [ , <var>options</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-initializemessageformat" title="InitializeMessageFormat ( messageFormat, locales, source, options )"><span class="secnum">1.1.2</span> InitializeMessageFormat ( <var>messageFormat</var>, <var>locales</var>, <var>source</var>, <var>options</var> )</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-properties-of-intl-messageformat-constructor" title="Properties of the Intl.MessageFormat Constructor"><span class="secnum">1.2</span> Properties of the Intl.MessageFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype" title="Intl.MessageFormat.prototype"><span class="secnum">1.2.1</span> Intl.MessageFormat.prototype</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat-internal-slots" title="Internal slots"><span class="secnum">1.2.2</span> Internal slots</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-properties-of-intl-messageformat-prototype-object" title="Properties of the Intl.MessageFormat Prototype Object"><span class="secnum">1.3</span> Properties of the Intl.MessageFormat Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype.constructor" title="Intl.MessageFormat.prototype.constructor"><span class="secnum">1.3.1</span> Intl.MessageFormat.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype-tostringtag" title="Intl.MessageFormat.prototype [ @@toStringTag ]"><span class="secnum">1.3.2</span> Intl.MessageFormat.prototype [ @@toStringTag ]</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype.format" title="Intl.MessageFormat.prototype.format ( [ values [ , onError ] ] )"><span class="secnum">1.3.3</span> Intl.MessageFormat.prototype.format ( [ <var>values</var> [ , <var>onError</var> ] ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype.formatToParts" title="Intl.MessageFormat.prototype.formatToParts ( [ values [ , onError ] ] )"><span class="secnum">1.3.4</span> Intl.MessageFormat.prototype.formatToParts ( [ <var>values</var> [ , <var>onError</var> ] ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype.resolvedoptions" title="Intl.MessageFormat.prototype.resolvedOptions ( )"><span class="secnum">1.3.5</span> Intl.MessageFormat.prototype.resolvedOptions ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-properties-of-intl-messageformat-instances" title="Properties of Intl.MessageFormat Instances"><span class="secnum">1.4</span> Properties of Intl.MessageFormat Instances</a></li><li><span class="item-toggle">+</span><a href="#sec-intl-messageformat-abstracts" title="Abstract Operations for MessageFormat Objects"><span class="secnum">1.5</span> Abstract Operations for MessageFormat Objects</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-getmessagedata" title="GetMessageData ( source )"><span class="secnum">1.5.1</span> GetMessageData ( <var>source</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-handledatetimeinput" title="HandleDateTimeInput ( input, opts )"><span class="secnum">1.5.2</span> HandleDateTimeInput ( <var>input</var>, <var>opts</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-datetimemessagevalue" title="
@@ -3007,7 +3245,7 @@ li.menu-search-result-term:before {
       The MessageFormat constructor is the <dfn tabindex="-1">%MessageFormat%</dfn> intrinsic object
       and a standard built-in property of the Intl object.
       Behaviour common to all service constructor properties of the Intl object
-      is specified in <a href="https://tc39.es/ecma402/#sec-internal-slots">9.1</a>.
+      is specified in <a href="https://tc39.es/ecma402/#sec-internal-slots" data-print-href="">9.1</a>.
     </p>
 
     <emu-clause id="sec-intl.messageformat">
@@ -3019,7 +3257,7 @@ li.menu-search-result-term:before {
       </p>
 
       <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>messageFormat</var> be ?&nbsp;OrdinaryCreateFromConstructor(NewTarget, <emu-xref href="#sec-properties-of-intl-messageformat-prototype-object" id="_ref_7"><a href="#sec-properties-of-intl-messageformat-prototype-object">%MessageFormat.prototype%</a></emu-xref>,
-           « <var class="field">[[InitializedMessageFormat]]</var>, <var class="field">[[LocaleMatcher]]</var>, <var class="field">[[MessageData]]</var>, <var class="field">[[RequestedLocales]]</var>, <var class="field">[[Runtime]]</var>&nbsp;»).</li><li>Return ?&nbsp;<emu-xref aoid="InitializeMessageFormat" id="_ref_8"><a href="#sec-initializemessageformat">InitializeMessageFormat</a></emu-xref>(<var>messageFormat</var>, <var>locales</var>, <var>source</var>, <var>options</var>).</li></ol></emu-alg>
+           « <var class="field">[[InitializedMessageFormat]]</var>, <var class="field">[[LocaleMatcher]]</var>, <var class="field">[[MessageData]]</var>, <var class="field">[[RequestedLocales]]</var>, <var class="field">[[Runtime]]</var> »).</li><li>Return ?&nbsp;<emu-xref aoid="InitializeMessageFormat" id="_ref_8"><a href="#sec-initializemessageformat">InitializeMessageFormat</a></emu-xref>(<var>messageFormat</var>, <var>locales</var>, <var>source</var>, <var>options</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-initializemessageformat" aoid="InitializeMessageFormat">
@@ -3033,7 +3271,7 @@ li.menu-search-result-term:before {
       </p>
 
       <emu-alg><ol><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>If <var>source</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>msgData</var> be ?&nbsp;<emu-xref aoid="GetMessageData" id="_ref_9"><a href="#sec-getmessagedata">GetMessageData</a></emu-xref>(<var>source</var>).</li><li>Set <var>options</var> to ?&nbsp;GetOptionsObject(<var>options</var>).</li><li>Let <var>matcher</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>,
-           « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val>&nbsp;», <emu-val>"best fit"</emu-val>).</li><li>Let <var>userFunctions</var> be ?&nbsp;Get(<var>options</var>, <emu-val>"functions"</emu-val>).</li><li>Let <var>functions</var> be ?&nbsp;<emu-xref aoid="GetMessageFunctions" id="_ref_10"><a href="#sec-getmessagefunctions">GetMessageFunctions</a></emu-xref>(<var>userFunctions</var>).</li><li>Set <var>messageFormat</var>.<var class="field">[[MessageData]]</var> to <var>msgData</var>.</li><li>Set <var>messageFormat</var>.<var class="field">[[RequestedLocales]]</var> to <var>requestedLocales</var>.</li><li>Set <var>messageFormat</var>.<var class="field">[[LocaleMatcher]]</var> to <var>matcher</var>.</li><li>Set <var>messageFormat</var>.<var class="field">[[Functions]]</var> to <var>functions</var>.</li><li>Return <var>messageFormat</var>.</li></ol></emu-alg>
+           « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>Let <var>userFunctions</var> be ?&nbsp;Get(<var>options</var>, <emu-val>"functions"</emu-val>).</li><li>Let <var>functions</var> be ?&nbsp;<emu-xref aoid="GetMessageFunctions" id="_ref_10"><a href="#sec-getmessagefunctions">GetMessageFunctions</a></emu-xref>(<var>userFunctions</var>).</li><li>Set <var>messageFormat</var>.<var class="field">[[MessageData]]</var> to <var>msgData</var>.</li><li>Set <var>messageFormat</var>.<var class="field">[[RequestedLocales]]</var> to <var>requestedLocales</var>.</li><li>Set <var>messageFormat</var>.<var class="field">[[LocaleMatcher]]</var> to <var>matcher</var>.</li><li>Set <var>messageFormat</var>.<var class="field">[[Functions]]</var> to <var>functions</var>.</li><li>Return <var>messageFormat</var>.</li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 
@@ -3183,7 +3421,7 @@ li.menu-search-result-term:before {
       </li>
       <li>
         <var class="field">[[MessageData]]</var> is an Object conforming to the
-        <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json">JSON Schema definition</a>
+        <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json" data-print-href="">JSON Schema definition</a>
         of the Unicode MessageFormat 2.0 specification.
       </li>
       <li>
@@ -3200,10 +3438,10 @@ li.menu-search-result-term:before {
 
     <emu-clause id="sec-getmessagedata" type="implementation-defined abstract operation" aoid="GetMessageData">
       <h1><span class="secnum">1.5.1</span> GetMessageData ( <var>source</var> )</h1>
-      <p>The implementation-defined abstract operation GetMessageData takes argument <var>source</var> (a String or an Object) and returns an Object conforming to the <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json">JSON Schema definition</a> of a message according to the Unicode MessageFormat 2.0 specification.</p>
+      <p>The implementation-defined abstract operation GetMessageData takes argument <var>source</var> (a String or an Object) and returns an Object conforming to the <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json" data-print-href="">JSON Schema definition</a> of a message according to the Unicode MessageFormat 2.0 specification.</p>
           <p>
             If <var>source</var> is a String, it returns the message data representation corresponding to the input <var>source</var> according to the
-            <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/syntax.md">Unicode MessageFormat 2.0 syntax</a>.
+            <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/syntax.md" data-print-href="">Unicode MessageFormat 2.0 syntax</a>.
             If <var>source</var> is an Object, it checks that <var>source</var> holds a valid message data representation,
             and returns an equivalent Object that is not affected by any further changes to <var>source</var>.
           </p>
@@ -3378,7 +3616,7 @@ li.menu-search-result-term:before {
         <h1><span class="secnum">1.5.6.1</span> SelectPattern ( <var>ctx</var> )</h1>
         <p>The abstract operation SelectPattern takes argument <var>ctx</var> (a <emu-xref href="#messageformatcontext-record" id="_ref_33"><a href="#messageformatcontext-record">MessageFormatContext Record</a></emu-xref>) and returns a List of Strings and Objects with an internal slot <var class="field">[[MessageValue]]</var>. It selects the pattern to format from the message data model. It performs the following steps when called:</p>
 
-        <emu-alg><ol><li>Let <var>msgData</var> be <var>ctx</var>.<var class="field">[[MessageFormat]]</var>.<var class="field">[[MessageData]]</var>.</li><li>Let <var>msgType</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"type"</emu-val>).</li><li>If <var>msgType</var> is <emu-val>"message"</emu-val>, then<ol><li>Let <var>pattern</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"pattern"</emu-val>).</li></ol></li><li>Else,<ol><li>Assert: <var>msgType</var> is <emu-val>"select"</emu-val>.</li><li>Let <var>selectorsData</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"selectors"</emu-val>).</li><li>Let <var>selectorExpressions</var> be ?&nbsp;CreateListFromArrayLike(<var>selectorsData</var>, « Object&nbsp;»).</li><li>Let <var>selectors</var> be an empty List.</li><li>For each element <var>selExp</var> of <var>selectorExpressions</var>,<ol><li>Let <var>sel</var> be <emu-xref aoid="ResolveExpression" id="_ref_34"><a href="#sec-resolveexpression">ResolveExpression</a></emu-xref>(<var>ctx</var>, <var>selExp</var>).</li><li>Let <var>selectKey</var> be ?&nbsp;Get(<var>sel</var>.<var class="field">[[MessageValue]]</var>, <emu-val>"selectKey"</emu-val>).</li><li>If IsCallable(<var>selectKey</var>) is <emu-val>true</emu-val>, then<ol><li>Append <var>sel</var>.<var class="field">[[MessageValue]]</var> to <var>selectors</var>.</li></ol></li><li>Else,<ol><li>Let <var>error</var> be ThrowCompletion(<emu-val>TypeError</emu-val>).</li><li>Perform ?&nbsp;<emu-xref aoid="HandleMessageFormatError" id="_ref_35"><a href="#sec-handlemessageformaterror">HandleMessageFormatError</a></emu-xref>(<var>ctx</var>, <var>error</var>).</li><li>Append <emu-val>null</emu-val> to <var>selectors</var>.</li></ol></li></ol></li><li>Let <var>variantsArray</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"variants"</emu-val>).</li><li>Let <var>variants</var> be ?&nbsp;CreateListFromArrayLike(<var>variantsArray</var>, « Object&nbsp;»).</li><li>Let <var>selectedVariant</var> be ?&nbsp;<emu-xref aoid="SelectVariant" id="_ref_36"><a href="#sec-selectvariant">SelectVariant</a></emu-xref>(<var>ctx</var>, <var>selectors</var>, <var>variants</var>).</li></ol></li><li>Return ?&nbsp;CreateListFromArrayLike(<var>pattern</var>, « String, Object&nbsp;»).</li></ol></emu-alg>
+        <emu-alg><ol><li>Let <var>msgData</var> be <var>ctx</var>.<var class="field">[[MessageFormat]]</var>.<var class="field">[[MessageData]]</var>.</li><li>Let <var>msgType</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"type"</emu-val>).</li><li>If <var>msgType</var> is <emu-val>"message"</emu-val>, then<ol><li>Let <var>pattern</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"pattern"</emu-val>).</li></ol></li><li>Else,<ol><li>Assert: <var>msgType</var> is <emu-val>"select"</emu-val>.</li><li>Let <var>selectorsData</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"selectors"</emu-val>).</li><li>Let <var>selectorExpressions</var> be ?&nbsp;CreateListFromArrayLike(<var>selectorsData</var>, « Object »).</li><li>Let <var>selectors</var> be an empty List.</li><li>For each element <var>selExp</var> of <var>selectorExpressions</var>,<ol><li>Let <var>sel</var> be <emu-xref aoid="ResolveExpression" id="_ref_34"><a href="#sec-resolveexpression">ResolveExpression</a></emu-xref>(<var>ctx</var>, <var>selExp</var>).</li><li>Let <var>selectKey</var> be ?&nbsp;Get(<var>sel</var>.<var class="field">[[MessageValue]]</var>, <emu-val>"selectKey"</emu-val>).</li><li>If IsCallable(<var>selectKey</var>) is <emu-val>true</emu-val>, then<ol><li>Append <var>sel</var>.<var class="field">[[MessageValue]]</var> to <var>selectors</var>.</li></ol></li><li>Else,<ol><li>Let <var>error</var> be ThrowCompletion(<emu-val>TypeError</emu-val>).</li><li>Perform ?&nbsp;<emu-xref aoid="HandleMessageFormatError" id="_ref_35"><a href="#sec-handlemessageformaterror">HandleMessageFormatError</a></emu-xref>(<var>ctx</var>, <var>error</var>).</li><li>Append <emu-val>null</emu-val> to <var>selectors</var>.</li></ol></li></ol></li><li>Let <var>variantsArray</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"variants"</emu-val>).</li><li>Let <var>variants</var> be ?&nbsp;CreateListFromArrayLike(<var>variantsArray</var>, « Object »).</li><li>Let <var>selectedVariant</var> be ?&nbsp;<emu-xref aoid="SelectVariant" id="_ref_36"><a href="#sec-selectvariant">SelectVariant</a></emu-xref>(<var>ctx</var>, <var>selectors</var>, <var>variants</var>).</li></ol></li><li>Return ?&nbsp;CreateListFromArrayLike(<var>pattern</var>, « String, Object »).</li></ol></emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-selectvariant" type="implementation-defined abstract operation" aoid="SelectVariant">
@@ -3387,7 +3625,7 @@ li.menu-search-result-term:before {
             <p>
               It applies the variant selection method defined by
               the "Resolve Preferences", "Filter Variants", and "Sort Variants" steps of the
-              <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/formatting.md#pattern-selection">Pattern Selection</a>
+              <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/formatting.md#pattern-selection" data-print-href="">Pattern Selection</a>
               section of the Unicode MessageFormat 2.0 specification.
             </p>
 
@@ -3400,7 +3638,7 @@ li.menu-search-result-term:before {
 
             <p>
               The value returned by this operation must be an Object matching the JSON Schema definition of a message pattern:
-              <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json#/$defs/pattern">
+              <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json#/$defs/pattern" data-print-href="">
                 https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json#/$defs/pattern
               </a>.
             </p>
@@ -3458,7 +3696,7 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.5.10</span> HandleMessageFormatError ( <var>ctx</var>, <var>completionRecord</var> )</h1>
       <p>The abstract operation HandleMessageFormatError takes arguments <var>ctx</var> (a <emu-xref href="#messageformatcontext-record" id="_ref_62"><a href="#messageformatcontext-record">MessageFormatContext Record</a></emu-xref>) and <var>completionRecord</var> (a Completion Record). It handles errors during formatting. It performs the following steps when called:</p>
 
-      <emu-alg><ol><li>Assert: <var>completionRecord</var> is a Completion Record.</li><li>Assert: <var>completionRecord</var> is an abrupt completion.</li><li>Let <var>onError</var> be <var>ctx</var>.<var class="field">[[OnError]]</var>.</li><li>Let <var>error</var> be <var>completionRecord</var>.<var class="field">[[Value]]</var>.</li><li>If <var>onError</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform ?&nbsp;Call(<var>onError</var>, <emu-val>undefined</emu-val>, « <var>error</var>&nbsp;»).</li></ol></li><li>Else if an appropriate notification mechanism exists, then<ol><li>Issue a warning for <var>error</var>.</li></ol></li></ol></emu-alg>
+      <emu-alg><ol><li>Assert: <var>completionRecord</var> is a Completion Record.</li><li>Assert: <var>completionRecord</var> is an abrupt completion.</li><li>Let <var>onError</var> be <var>ctx</var>.<var class="field">[[OnError]]</var>.</li><li>Let <var>error</var> be <var>completionRecord</var>.<var class="field">[[Value]]</var>.</li><li>If <var>onError</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform ?&nbsp;Call(<var>onError</var>, <emu-val>undefined</emu-val>, « <var>error</var> »).</li></ol></li><li>Else if an appropriate notification mechanism exists, then<ol><li>Issue a warning for <var>error</var>.</li></ol></li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-resolvefallback" type="abstract operation" aoid="ResolveFallback">

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (e.code === 'Escape') {
         sdoBox.deactivate();
       }
-    }),
+    })
   );
 });
 
@@ -99,11 +99,11 @@ function Search(menu) {
 
   this.$searchBox.addEventListener(
     'keydown',
-    debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }),
+    debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true })
   );
   this.$searchBox.addEventListener(
     'keyup',
-    debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }),
+    debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true })
   );
 
   // Perform an initial search if the box is not empty.
@@ -303,6 +303,7 @@ Search.prototype.displayResults = function (results) {
       }
 
       if (text) {
+        // prettier-ignore
         html += `<li class=menu-search-result-${cssClass}><a href="${makeLinkToId(id)}">${text}</a></li>`;
       }
     });
@@ -484,7 +485,7 @@ function findActiveClause(root, path) {
     let marginTop = Math.max(
       0,
       parseInt(clauseStyles['margin-top']),
-      parseInt(getComputedStyle($header)['margin-top']),
+      parseInt(getComputedStyle($header)['margin-top'])
     );
     let marginBottom = Math.max(0, parseInt(clauseStyles['margin-bottom']));
     let crossesMidpoint =
@@ -582,6 +583,7 @@ Menu.prototype.addPinEntry = function (id) {
     } else {
       prefix = '';
     }
+    // prettier-ignore
     text = `${prefix}${entry.titleHTML}`;
   } else {
     text = getKey(entry);
@@ -859,9 +861,7 @@ let referencePane = {
     this.$tableContainer.appendChild(this.$table);
     this.$pane.appendChild(this.$tableContainer);
 
-    if (menu != null) {
-      menu.$specContainer.appendChild(this.$container);
-    }
+    menu.$specContainer.appendChild(this.$container);
   },
 
   activate() {
@@ -930,6 +930,7 @@ let referencePane = {
       e.parentNode.replaceChild(document.createTextNode(e.textContent), e);
     });
 
+    // prettier-ignore
     this.$headerText.innerHTML = `Syntax-Directed Operations for<br><a href="${makeLinkToId(alternativeId)}" class="menu-pane-header-production"><emu-nt>${parentName}</emu-nt> ${colons.outerHTML} </a>`;
     this.$headerText.querySelector('a').append(rhs);
     this.showSDOsBody(sdos, alternativeId);
@@ -1196,16 +1197,13 @@ function doShortcut(e) {
 }
 
 function init() {
-  if (document.getElementById('menu') == null) {
-    return;
-  }
   menu = new Menu();
   let $container = document.getElementById('spec-container');
   $container.addEventListener(
     'mouseover',
     debounce(e => {
       Toolbox.activateIfMouseOver(e);
-    }),
+    })
   );
   document.addEventListener(
     'keydown',
@@ -1216,7 +1214,7 @@ function init() {
         }
         document.getElementById('shortcuts-help').classList.remove('active');
       }
-    }),
+    })
   );
 }
 
@@ -1371,7 +1369,7 @@ window.addEventListener('beforeunload', () => {
 // https://w3c.github.io/csswg-drafts/css-counter-styles/
 
 const lowerLetters = Array.from({ length: 26 }, (_, i) =>
-  String.fromCharCode('a'.charCodeAt(0) + i),
+  String.fromCharCode('a'.charCodeAt(0) + i)
 );
 // Implement the lower-alpha 'alphabetic' algorithm,
 // adjusting for indexing from 0 rather than 1.
@@ -1442,7 +1440,7 @@ const counterByDepth = [];
 function addStepNumberText(
   ol,
   depth = 0,
-  special = [...ol.classList].some(c => c.startsWith('nested-')),
+  special = [...ol.classList].some(c => c.startsWith('nested-'))
 ) {
   let counter = !special && counterByDepth[depth];
   if (!counter) {
@@ -1559,7 +1557,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 let sdoMap = JSON.parse(`{}`);
-let biblio = JSON.parse(`{"refsByClause":{"sec-intl.messageformat.prototype.resolvedoptions":["_ref_0"],"sec-getmessagefunctions":["_ref_1","_ref_2","_ref_3","_ref_4","_ref_5"],"sec-messagecontextrecord":["_ref_6"],"sec-intl.messageformat":["_ref_7","_ref_8"],"sec-initializemessageformat":["_ref_9","_ref_10"],"sec-intl.messageformat.prototype":["_ref_11"],"sec-intl.messageformat.prototype.constructor":["_ref_12"],"sec-intl.messageformat.prototype.format":["_ref_13","_ref_14","_ref_15","_ref_16","_ref_17"],"sec-intl.messageformat.prototype.formatToParts":["_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23"],"sec-properties-of-intl-messageformat-instances":["_ref_24"],"sec-messageformat-datetimefunctions":["_ref_25"],"sec-messageformat-datefunctions":["_ref_26"],"sec-messageformat-timefunctions":["_ref_27"],"sec-createmessageformatcontext":["_ref_28","_ref_29"],"sec-resolvemessage":["_ref_30","_ref_31","_ref_32"],"sec-selectpattern":["_ref_33","_ref_34","_ref_35","_ref_36"],"sec-selectvariant":["_ref_37","_ref_38"],"sec-resolveexpression":["_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45"],"sec-resolvefunction":["_ref_46","_ref_47","_ref_48","_ref_49","_ref_50","_ref_51","_ref_52","_ref_53"],"sec-formatmarkuppart":["_ref_54","_ref_55","_ref_56"],"sec-getsource":["_ref_57","_ref_58","_ref_59","_ref_60","_ref_61"],"sec-handlemessageformaterror":["_ref_62"],"sec-resolvefallback":["_ref_63","_ref_64"],"sec-resolvevalue":["_ref_65","_ref_66","_ref_67","_ref_68","_ref_69","_ref_70","_ref_71","_ref_72","_ref_73"]},"entries":[{"type":"term","term":"%MessageFormat%","refId":"sec-intl-messageformat-constructor"},{"type":"clause","id":"sec-intl.messageformat","title":"Intl.MessageFormat ( source, [ locales [ , options ] ] )","titleHTML":"Intl.MessageFormat ( <var>source</var>, [ <var>locales</var> [ , <var>options</var> ] ] )","number":"1.1.1"},{"type":"op","aoid":"InitializeMessageFormat","refId":"sec-initializemessageformat"},{"type":"clause","id":"sec-initializemessageformat","title":"InitializeMessageFormat ( messageFormat, source, locales, options )","titleHTML":"InitializeMessageFormat ( <var>messageFormat</var>, <var>source</var>, <var>locales</var>, <var>options</var> )","number":"1.1.2","referencingIds":["_ref_8"]},{"type":"clause","id":"sec-intl-messageformat-constructor","titleHTML":"The Intl.MessageFormat Constructor","number":"1.1","referencingIds":["_ref_12"]},{"type":"clause","id":"sec-intl.messageformat.prototype","titleHTML":"Intl.MessageFormat.prototype","number":"1.2.1"},{"type":"clause","id":"sec-intl.messageformat-internal-slots","titleHTML":"Internal slots","number":"1.2.2"},{"type":"clause","id":"sec-properties-of-intl-messageformat-constructor","titleHTML":"Properties of the Intl.MessageFormat Constructor","number":"1.2"},{"type":"term","term":"%MessageFormat.prototype%","refId":"sec-properties-of-intl-messageformat-prototype-object"},{"type":"clause","id":"sec-intl.messageformat.prototype.constructor","titleHTML":"Intl.MessageFormat.prototype.constructor","number":"1.3.1"},{"type":"clause","id":"sec-intl.messageformat.prototype-tostringtag","titleHTML":"Intl.MessageFormat.prototype [ @@toStringTag ]","number":"1.3.2"},{"type":"clause","id":"sec-intl.messageformat.prototype.format","title":"Intl.MessageFormat.prototype.format ( [ values [ , onError ] ] )","titleHTML":"Intl.MessageFormat.prototype.format ( [ <var>values</var> [ , <var>onError</var> ] ] )","number":"1.3.3"},{"type":"clause","id":"sec-intl.messageformat.prototype.formatToParts","title":"Intl.MessageFormat.prototype.formatToParts ( [ values [ , onError ] ] )","titleHTML":"Intl.MessageFormat.prototype.formatToParts ( [ <var>values</var> [ , <var>onError</var> ] ] )","number":"1.3.4"},{"type":"table","id":"table-messageformat-resolvedoptions-properties","number":1,"caption":"Table 1: Resolved Options of MessageFormat Instances","referencingIds":["_ref_0"]},{"type":"clause","id":"sec-intl.messageformat.prototype.resolvedoptions","titleHTML":"Intl.MessageFormat.prototype.resolvedOptions ( )","number":"1.3.5"},{"type":"clause","id":"sec-properties-of-intl-messageformat-prototype-object","titleHTML":"Properties of the Intl.MessageFormat Prototype Object","number":"1.3","referencingIds":["_ref_7","_ref_11","_ref_24"]},{"type":"clause","id":"sec-properties-of-intl-messageformat-instances","titleHTML":"Properties of Intl.MessageFormat Instances","number":"1.4"},{"type":"op","aoid":"GetMessageData","refId":"sec-getmessagedata"},{"type":"clause","id":"sec-getmessagedata","title":"GetMessageData ( source )","titleHTML":"GetMessageData ( <var>source</var> )","number":"1.5.1","referencingIds":["_ref_9"]},{"type":"op","aoid":"HandleDateTimeInput","refId":"sec-handledatetimeinput"},{"type":"clause","id":"sec-handledatetimeinput","title":"HandleDateTimeInput ( input, opts )","titleHTML":"HandleDateTimeInput ( <var>input</var>, <var>opts</var> )","number":"1.5.2","referencingIds":["_ref_25","_ref_26","_ref_27"]},{"type":"clause","id":"sec-datetimemessagevalue","title":"\\n        DateTimeMessageValue (\\n          value: a Date object,\\n          opts: an Object,\\n          funcCtx: an Object,\\n        ): an ECMAScript value\\n      ","titleHTML":"\\n        DateTimeMessageValue (\\n          <var>value</var>: a Date object,\\n          <var>opts</var>: an Object,\\n          <var>funcCtx</var>: an Object,\\n        ): an ECMAScript value\\n      ","number":"1.5.3"},{"type":"clause","id":"sec-messageformat-numberfunctions","titleHTML":"MessageFormat Number Functions","number":"1.5.4.1","referencingIds":["_ref_1"]},{"type":"clause","id":"sec-messageformat-stringfunctions","titleHTML":"MessageFormat String Functions","number":"1.5.4.2","referencingIds":["_ref_2"]},{"type":"clause","id":"sec-messageformat-datetimefunctions","titleHTML":"MessageFormat DateTime Functions","number":"1.5.4.3","referencingIds":["_ref_3"]},{"type":"clause","id":"sec-messageformat-datefunctions","titleHTML":"MessageFormat Date Functions","number":"1.5.4.4","referencingIds":["_ref_4"]},{"type":"clause","id":"sec-messageformat-timefunctions","titleHTML":"MessageFormat Time Functions","number":"1.5.4.5","referencingIds":["_ref_5"]},{"type":"op","aoid":"GetMessageFunctions","refId":"sec-getmessagefunctions"},{"type":"clause","id":"sec-getmessagefunctions","title":"GetMessageFunctions ( userFunctions )","titleHTML":"GetMessageFunctions ( <var>userFunctions</var> )","number":"1.5.4","referencingIds":["_ref_10"]},{"type":"term","term":"MessageFormatContext Record","id":"messageformatcontext-record","referencingIds":["_ref_28","_ref_29","_ref_30","_ref_33","_ref_37","_ref_39","_ref_46","_ref_54","_ref_57","_ref_62","_ref_65"]},{"type":"table","id":"table-messageformatcontext-record","number":2,"caption":"Table 2: Record returned by CreateMessageContext","referencingIds":["_ref_6"]},{"type":"clause","id":"sec-messagecontextrecord","titleHTML":"MessageFormatContext Records","number":"1.5.5.1"},{"type":"op","aoid":"CreateMessageFormatContext","refId":"sec-createmessageformatcontext"},{"type":"clause","id":"sec-createmessageformatcontext","title":"CreateMessageFormatContext ( mf, values, onError )","titleHTML":"CreateMessageFormatContext ( <var>mf</var>, <var>values</var>, <var>onError</var> )","number":"1.5.5","referencingIds":["_ref_13","_ref_18"]},{"type":"op","aoid":"SelectPattern","refId":"sec-selectpattern"},{"type":"clause","id":"sec-selectpattern","title":"SelectPattern ( ctx )","titleHTML":"SelectPattern ( <var>ctx</var> )","number":"1.5.6.1","referencingIds":["_ref_31"]},{"type":"op","aoid":"SelectVariant","refId":"sec-selectvariant"},{"type":"clause","id":"sec-selectvariant","title":"SelectVariant ( ctx, selectors, variants )","titleHTML":"SelectVariant ( <var>ctx</var>, <var>selectors</var>, <var>variants</var> )","number":"1.5.6.2","referencingIds":["_ref_36"]},{"type":"op","aoid":"ResolveMessage","refId":"sec-resolvemessage"},{"type":"clause","id":"sec-resolvemessage","title":"ResolveMessage ( ctx )","titleHTML":"ResolveMessage ( <var>ctx</var> )","number":"1.5.6","referencingIds":["_ref_14","_ref_19"]},{"type":"op","aoid":"ResolveFunction","refId":"sec-resolvefunction"},{"type":"clause","id":"sec-resolvefunction","title":"ResolveFunction ( ctx, source, resArg, annotation )","titleHTML":"ResolveFunction ( <var>ctx</var>, <var>source</var>, <var>resArg</var>, <var>annotation</var> )","number":"1.5.7.1","referencingIds":["_ref_45"]},{"type":"op","aoid":"ResolveUnknown","refId":"sec-resolveunknown"},{"type":"clause","id":"sec-resolveunknown","title":"ResolveUnknown ( source, value )","titleHTML":"ResolveUnknown ( <var>source</var>, <var>value</var> )","number":"1.5.7.2","referencingIds":["_ref_42"]},{"type":"op","aoid":"ResolveExpression","refId":"sec-resolveexpression"},{"type":"clause","id":"sec-resolveexpression","title":"ResolveExpression ( ctx, expression )","titleHTML":"ResolveExpression ( <var>ctx</var>, <var>expression</var> )","number":"1.5.7","referencingIds":["_ref_32","_ref_34","_ref_69","_ref_70"]},{"type":"op","aoid":"FormatMarkupPart","refId":"sec-formatmarkuppart"},{"type":"clause","id":"sec-formatmarkuppart","title":"FormatMarkupPart ( ctx, markup )","titleHTML":"FormatMarkupPart ( <var>ctx</var>, <var>markup</var> )","number":"1.5.8","referencingIds":["_ref_20"]},{"type":"op","aoid":"MessageValueSource","refId":"sec-messagevaluesource"},{"type":"clause","id":"sec-messagevaluesource","title":"MessageValueSource ( mv )","titleHTML":"MessageValueSource ( <var>mv</var> )","number":"1.5.9.1","referencingIds":["_ref_16","_ref_22","_ref_59"]},{"type":"op","aoid":"GetSource","refId":"sec-getsource"},{"type":"clause","id":"sec-getsource","title":"GetSource ( ctx, value )","titleHTML":"GetSource ( <var>ctx</var>, <var>value</var> )","number":"1.5.9","referencingIds":["_ref_40","_ref_58","_ref_60","_ref_61","_ref_67","_ref_72"]},{"type":"op","aoid":"HandleMessageFormatError","refId":"sec-handlemessageformaterror"},{"type":"clause","id":"sec-handlemessageformaterror","title":"HandleMessageFormatError ( ctx, completionRecord )","titleHTML":"HandleMessageFormatError ( <var>ctx</var>, <var>completionRecord</var> )","number":"1.5.10","referencingIds":["_ref_15","_ref_21","_ref_35","_ref_38","_ref_43","_ref_47","_ref_50","_ref_52","_ref_56","_ref_66","_ref_71"]},{"type":"op","aoid":"MessageFallbackPart","refId":"sec-messagefallbackpart"},{"type":"clause","id":"sec-messagefallbackpart","title":"MessageFallbackPart ( source )","titleHTML":"MessageFallbackPart ( <var>source</var> )","number":"1.5.11.1","referencingIds":["_ref_23","_ref_63"]},{"type":"op","aoid":"MessageFallbackString","refId":"sec-messagefallbackstring"},{"type":"clause","id":"sec-messagefallbackstring","title":"MessageFallbackString ( source )","titleHTML":"MessageFallbackString ( <var>source</var> )","number":"1.5.11.2","referencingIds":["_ref_17","_ref_64"]},{"type":"op","aoid":"ResolveFallback","refId":"sec-resolvefallback"},{"type":"clause","id":"sec-resolvefallback","title":"ResolveFallback ( source )","titleHTML":"ResolveFallback ( <var>source</var> )","number":"1.5.11","referencingIds":["_ref_44","_ref_48","_ref_51","_ref_53","_ref_68","_ref_73"]},{"type":"op","aoid":"ResolveValue","refId":"sec-resolvevalue"},{"type":"clause","id":"sec-resolvevalue","title":"ResolveValue ( ctx, value )","titleHTML":"ResolveValue ( <var>ctx</var>, <var>value</var> )","number":"1.5.12","referencingIds":["_ref_41","_ref_49","_ref_55"]},{"type":"clause","id":"sec-intl-messageformat-abstracts","titleHTML":"Abstract Operations for MessageFormat Objects","number":"1.5"},{"type":"clause","id":"messageformat-objects","titleHTML":"MessageFormat Objects","number":"1"},{"type":"clause","id":"sec-copyright-and-software-license","title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A"}]}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-intl.messageformat.prototype.resolvedoptions":["_ref_0"],"sec-getmessagefunctions":["_ref_1","_ref_2","_ref_3","_ref_4","_ref_5"],"sec-messagecontextrecord":["_ref_6"],"sec-intl.messageformat":["_ref_7","_ref_8"],"sec-initializemessageformat":["_ref_9","_ref_10"],"sec-intl.messageformat.prototype":["_ref_11"],"sec-intl.messageformat.prototype.constructor":["_ref_12"],"sec-intl.messageformat.prototype.format":["_ref_13","_ref_14","_ref_15","_ref_16","_ref_17"],"sec-intl.messageformat.prototype.formatToParts":["_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23"],"sec-properties-of-intl-messageformat-instances":["_ref_24"],"sec-messageformat-datetimefunctions":["_ref_25"],"sec-messageformat-datefunctions":["_ref_26"],"sec-messageformat-timefunctions":["_ref_27"],"sec-createmessageformatcontext":["_ref_28","_ref_29"],"sec-resolvemessage":["_ref_30","_ref_31","_ref_32"],"sec-selectpattern":["_ref_33","_ref_34","_ref_35","_ref_36"],"sec-selectvariant":["_ref_37","_ref_38"],"sec-resolveexpression":["_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45"],"sec-resolvefunction":["_ref_46","_ref_47","_ref_48","_ref_49","_ref_50","_ref_51","_ref_52","_ref_53"],"sec-formatmarkuppart":["_ref_54","_ref_55","_ref_56"],"sec-getsource":["_ref_57","_ref_58","_ref_59","_ref_60","_ref_61"],"sec-handlemessageformaterror":["_ref_62"],"sec-resolvefallback":["_ref_63","_ref_64"],"sec-resolvevalue":["_ref_65","_ref_66","_ref_67","_ref_68","_ref_69","_ref_70","_ref_71","_ref_72","_ref_73"]},"entries":[{"type":"term","term":"%MessageFormat%","refId":"sec-intl-messageformat-constructor"},{"type":"clause","id":"sec-intl.messageformat","title":"Intl.MessageFormat ( locales, source [ , options ] )","titleHTML":"Intl.MessageFormat ( <var>locales</var>, <var>source</var> [ , <var>options</var> ] )","number":"1.1.1"},{"type":"op","aoid":"InitializeMessageFormat","refId":"sec-initializemessageformat"},{"type":"clause","id":"sec-initializemessageformat","title":"InitializeMessageFormat ( messageFormat, locales, source, options )","titleHTML":"InitializeMessageFormat ( <var>messageFormat</var>, <var>locales</var>, <var>source</var>, <var>options</var> )","number":"1.1.2","referencingIds":["_ref_8"]},{"type":"clause","id":"sec-intl-messageformat-constructor","titleHTML":"The Intl.MessageFormat Constructor","number":"1.1","referencingIds":["_ref_12"]},{"type":"clause","id":"sec-intl.messageformat.prototype","titleHTML":"Intl.MessageFormat.prototype","number":"1.2.1"},{"type":"clause","id":"sec-intl.messageformat-internal-slots","titleHTML":"Internal slots","number":"1.2.2"},{"type":"clause","id":"sec-properties-of-intl-messageformat-constructor","titleHTML":"Properties of the Intl.MessageFormat Constructor","number":"1.2"},{"type":"term","term":"%MessageFormat.prototype%","refId":"sec-properties-of-intl-messageformat-prototype-object"},{"type":"clause","id":"sec-intl.messageformat.prototype.constructor","titleHTML":"Intl.MessageFormat.prototype.constructor","number":"1.3.1"},{"type":"clause","id":"sec-intl.messageformat.prototype-tostringtag","titleHTML":"Intl.MessageFormat.prototype [ @@toStringTag ]","number":"1.3.2"},{"type":"clause","id":"sec-intl.messageformat.prototype.format","title":"Intl.MessageFormat.prototype.format ( [ values [ , onError ] ] )","titleHTML":"Intl.MessageFormat.prototype.format ( [ <var>values</var> [ , <var>onError</var> ] ] )","number":"1.3.3"},{"type":"clause","id":"sec-intl.messageformat.prototype.formatToParts","title":"Intl.MessageFormat.prototype.formatToParts ( [ values [ , onError ] ] )","titleHTML":"Intl.MessageFormat.prototype.formatToParts ( [ <var>values</var> [ , <var>onError</var> ] ] )","number":"1.3.4"},{"type":"table","id":"table-messageformat-resolvedoptions-properties","number":1,"caption":"Table 1: Resolved Options of MessageFormat Instances","referencingIds":["_ref_0"]},{"type":"clause","id":"sec-intl.messageformat.prototype.resolvedoptions","titleHTML":"Intl.MessageFormat.prototype.resolvedOptions ( )","number":"1.3.5"},{"type":"clause","id":"sec-properties-of-intl-messageformat-prototype-object","titleHTML":"Properties of the Intl.MessageFormat Prototype Object","number":"1.3","referencingIds":["_ref_7","_ref_11","_ref_24"]},{"type":"clause","id":"sec-properties-of-intl-messageformat-instances","titleHTML":"Properties of Intl.MessageFormat Instances","number":"1.4"},{"type":"op","aoid":"GetMessageData","refId":"sec-getmessagedata"},{"type":"clause","id":"sec-getmessagedata","title":"GetMessageData ( source )","titleHTML":"GetMessageData ( <var>source</var> )","number":"1.5.1","referencingIds":["_ref_9"]},{"type":"op","aoid":"HandleDateTimeInput","refId":"sec-handledatetimeinput"},{"type":"clause","id":"sec-handledatetimeinput","title":"HandleDateTimeInput ( input, opts )","titleHTML":"HandleDateTimeInput ( <var>input</var>, <var>opts</var> )","number":"1.5.2","referencingIds":["_ref_25","_ref_26","_ref_27"]},{"type":"clause","id":"sec-datetimemessagevalue","title":"\\n        DateTimeMessageValue (\\n          value: a Date object,\\n          opts: an Object,\\n          funcCtx: an Object,\\n        ): an ECMAScript value\\n      ","titleHTML":"\\n        DateTimeMessageValue (\\n          <var>value</var>: a Date object,\\n          <var>opts</var>: an Object,\\n          <var>funcCtx</var>: an Object,\\n        ): an ECMAScript value\\n      ","number":"1.5.3"},{"type":"clause","id":"sec-messageformat-numberfunctions","titleHTML":"MessageFormat Number Functions","number":"1.5.4.1","referencingIds":["_ref_1"]},{"type":"clause","id":"sec-messageformat-stringfunctions","titleHTML":"MessageFormat String Functions","number":"1.5.4.2","referencingIds":["_ref_2"]},{"type":"clause","id":"sec-messageformat-datetimefunctions","titleHTML":"MessageFormat DateTime Functions","number":"1.5.4.3","referencingIds":["_ref_3"]},{"type":"clause","id":"sec-messageformat-datefunctions","titleHTML":"MessageFormat Date Functions","number":"1.5.4.4","referencingIds":["_ref_4"]},{"type":"clause","id":"sec-messageformat-timefunctions","titleHTML":"MessageFormat Time Functions","number":"1.5.4.5","referencingIds":["_ref_5"]},{"type":"op","aoid":"GetMessageFunctions","refId":"sec-getmessagefunctions"},{"type":"clause","id":"sec-getmessagefunctions","title":"GetMessageFunctions ( userFunctions )","titleHTML":"GetMessageFunctions ( <var>userFunctions</var> )","number":"1.5.4","referencingIds":["_ref_10"]},{"type":"term","term":"MessageFormatContext Record","id":"messageformatcontext-record","referencingIds":["_ref_28","_ref_29","_ref_30","_ref_33","_ref_37","_ref_39","_ref_46","_ref_54","_ref_57","_ref_62","_ref_65"]},{"type":"table","id":"table-messageformatcontext-record","number":2,"caption":"Table 2: Record returned by CreateMessageContext","referencingIds":["_ref_6"]},{"type":"clause","id":"sec-messagecontextrecord","titleHTML":"MessageFormatContext Records","number":"1.5.5.1"},{"type":"op","aoid":"CreateMessageFormatContext","refId":"sec-createmessageformatcontext"},{"type":"clause","id":"sec-createmessageformatcontext","title":"CreateMessageFormatContext ( mf, values, onError )","titleHTML":"CreateMessageFormatContext ( <var>mf</var>, <var>values</var>, <var>onError</var> )","number":"1.5.5","referencingIds":["_ref_13","_ref_18"]},{"type":"op","aoid":"SelectPattern","refId":"sec-selectpattern"},{"type":"clause","id":"sec-selectpattern","title":"SelectPattern ( ctx )","titleHTML":"SelectPattern ( <var>ctx</var> )","number":"1.5.6.1","referencingIds":["_ref_31"]},{"type":"op","aoid":"SelectVariant","refId":"sec-selectvariant"},{"type":"clause","id":"sec-selectvariant","title":"SelectVariant ( ctx, selectors, variants )","titleHTML":"SelectVariant ( <var>ctx</var>, <var>selectors</var>, <var>variants</var> )","number":"1.5.6.2","referencingIds":["_ref_36"]},{"type":"op","aoid":"ResolveMessage","refId":"sec-resolvemessage"},{"type":"clause","id":"sec-resolvemessage","title":"ResolveMessage ( ctx )","titleHTML":"ResolveMessage ( <var>ctx</var> )","number":"1.5.6","referencingIds":["_ref_14","_ref_19"]},{"type":"op","aoid":"ResolveFunction","refId":"sec-resolvefunction"},{"type":"clause","id":"sec-resolvefunction","title":"ResolveFunction ( ctx, source, resArg, annotation )","titleHTML":"ResolveFunction ( <var>ctx</var>, <var>source</var>, <var>resArg</var>, <var>annotation</var> )","number":"1.5.7.1","referencingIds":["_ref_45"]},{"type":"op","aoid":"ResolveUnknown","refId":"sec-resolveunknown"},{"type":"clause","id":"sec-resolveunknown","title":"ResolveUnknown ( source, value )","titleHTML":"ResolveUnknown ( <var>source</var>, <var>value</var> )","number":"1.5.7.2","referencingIds":["_ref_42"]},{"type":"op","aoid":"ResolveExpression","refId":"sec-resolveexpression"},{"type":"clause","id":"sec-resolveexpression","title":"ResolveExpression ( ctx, expression )","titleHTML":"ResolveExpression ( <var>ctx</var>, <var>expression</var> )","number":"1.5.7","referencingIds":["_ref_32","_ref_34","_ref_69","_ref_70"]},{"type":"op","aoid":"FormatMarkupPart","refId":"sec-formatmarkuppart"},{"type":"clause","id":"sec-formatmarkuppart","title":"FormatMarkupPart ( ctx, markup )","titleHTML":"FormatMarkupPart ( <var>ctx</var>, <var>markup</var> )","number":"1.5.8","referencingIds":["_ref_20"]},{"type":"op","aoid":"MessageValueSource","refId":"sec-messagevaluesource"},{"type":"clause","id":"sec-messagevaluesource","title":"MessageValueSource ( mv )","titleHTML":"MessageValueSource ( <var>mv</var> )","number":"1.5.9.1","referencingIds":["_ref_16","_ref_22","_ref_59"]},{"type":"op","aoid":"GetSource","refId":"sec-getsource"},{"type":"clause","id":"sec-getsource","title":"GetSource ( ctx, value )","titleHTML":"GetSource ( <var>ctx</var>, <var>value</var> )","number":"1.5.9","referencingIds":["_ref_40","_ref_58","_ref_60","_ref_61","_ref_67","_ref_72"]},{"type":"op","aoid":"HandleMessageFormatError","refId":"sec-handlemessageformaterror"},{"type":"clause","id":"sec-handlemessageformaterror","title":"HandleMessageFormatError ( ctx, completionRecord )","titleHTML":"HandleMessageFormatError ( <var>ctx</var>, <var>completionRecord</var> )","number":"1.5.10","referencingIds":["_ref_15","_ref_21","_ref_35","_ref_38","_ref_43","_ref_47","_ref_50","_ref_52","_ref_56","_ref_66","_ref_71"]},{"type":"op","aoid":"MessageFallbackPart","refId":"sec-messagefallbackpart"},{"type":"clause","id":"sec-messagefallbackpart","title":"MessageFallbackPart ( source )","titleHTML":"MessageFallbackPart ( <var>source</var> )","number":"1.5.11.1","referencingIds":["_ref_23","_ref_63"]},{"type":"op","aoid":"MessageFallbackString","refId":"sec-messagefallbackstring"},{"type":"clause","id":"sec-messagefallbackstring","title":"MessageFallbackString ( source )","titleHTML":"MessageFallbackString ( <var>source</var> )","number":"1.5.11.2","referencingIds":["_ref_17","_ref_64"]},{"type":"op","aoid":"ResolveFallback","refId":"sec-resolvefallback"},{"type":"clause","id":"sec-resolvefallback","title":"ResolveFallback ( source )","titleHTML":"ResolveFallback ( <var>source</var> )","number":"1.5.11","referencingIds":["_ref_44","_ref_48","_ref_51","_ref_53","_ref_68","_ref_73"]},{"type":"op","aoid":"ResolveValue","refId":"sec-resolvevalue"},{"type":"clause","id":"sec-resolvevalue","title":"ResolveValue ( ctx, value )","titleHTML":"ResolveValue ( <var>ctx</var>, <var>value</var> )","number":"1.5.12","referencingIds":["_ref_41","_ref_49","_ref_55"]},{"type":"clause","id":"sec-intl-messageformat-abstracts","titleHTML":"Abstract Operations for MessageFormat Objects","number":"1.5"},{"type":"clause","id":"messageformat-objects","titleHTML":"MessageFormat Objects","number":"1"},{"type":"clause","id":"sec-copyright-and-software-license","title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A"}]}`);
 ;let usesMultipage = false</script><style>/* IBM Plex fonts (Latin subset) have been downloaded from Google Fonts and modified to add support back in for the `zero` substitution (slashed zeroes) */
 
 /* https://fonts.googleapis.com/css2?family=IBM%20Plex%20Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap */
@@ -1661,9 +1659,7 @@ body {
   word-wrap: break-word;
   font-size: 18px;
   line-height: 1.5;
-  font-family:
-    IBM Plex Serif,
-    serif;
+  font-family: IBM Plex Serif, serif;
   font-variant-numeric: slashed-zero;
   padding: 0;
   margin: 0;
@@ -1672,8 +1668,6 @@ body {
 
 #spec-container {
   padding: 0 20px;
-  max-width: 80rem;
-  margin: 0 auto;
   flex-grow: 1;
   flex-basis: 66%;
   box-sizing: border-box;
@@ -1719,9 +1713,7 @@ span.e-user-code::before {
   line-height: normal;
   vertical-align: middle;
   text-transform: uppercase;
-  font-family:
-    IBM Plex Sans,
-    sans-serif;
+  font-family: IBM Plex Sans, sans-serif;
   font-weight: 900;
   font-size: x-small;
 }
@@ -1744,10 +1736,7 @@ span.e-user-code::before {
 
 code {
   font-weight: bold;
-  font-family:
-    Comic Code,
-    IBM Plex Mono,
-    monospace;
+  font-family: Comic Code, IBM Plex Mono, monospace;
   white-space: pre;
 }
 
@@ -1812,9 +1801,7 @@ var.referenced6 {
 }
 
 emu-const {
-  font-family:
-    IBM Plex Sans,
-    sans-serif;
+  font-family: IBM Plex Sans, sans-serif;
   font-variant: small-caps;
   text-transform: uppercase;
 }
@@ -1878,17 +1865,16 @@ emu-eqn div:first-child {
 emu-note {
   margin: 1em 0;
   display: flex;
-  gap: 1em;
   flex-direction: row;
   color: inherit;
   border-left: 5px solid #52e052;
   background: #e9fbe9;
   padding: 10px 10px 10px 0;
-  overflow-x: auto;
 }
 
 emu-note > span.note {
-  white-space: nowrap;
+  flex-basis: 100px;
+  min-width: 100px;
   flex-grow: 0;
   flex-shrink: 1;
   text-transform: uppercase;
@@ -2014,9 +2000,7 @@ emu-rhs emu-nt {
 
 emu-t {
   display: inline-block;
-  font-family:
-    IBM Plex Mono,
-    monospace;
+  font-family: IBM Plex Mono, monospace;
   font-weight: bold;
   white-space: nowrap;
   text-indent: 0;
@@ -2051,9 +2035,7 @@ emu-mods {
 emu-params,
 emu-opt {
   margin-right: 1ex;
-  font-family:
-    IBM Plex Mono,
-    monospace;
+  font-family: IBM Plex Mono, monospace;
 }
 
 emu-params,
@@ -2067,9 +2049,7 @@ emu-opt {
 
 emu-gprose {
   font-size: 0.9em;
-  font-family:
-    IBM Plex Sans,
-    sans-serif;
+  font-family: IBM Plex Sans, sans-serif;
 }
 
 emu-production emu-gprose {
@@ -2293,8 +2273,7 @@ emu-annex emu-annex emu-annex emu-annex emu-annex emu-annex {
 /* Figures and tables */
 figure {
   display: block;
-  overflow-x: auto;
-  margin: 1.5em 0;
+  margin: 1em 0 3em 0;
 }
 figure object {
   display: block;
@@ -2357,7 +2336,7 @@ table.lightweight-table th {
     background-color: rgba(249, 241, 172, 1);
   }
   100% {
-    background-color: rgba(249, 241, 172, 0);
+    background-color: rgba(249, 241, 172, 0)
   }
 }
 #spec-container :target:not(emu-annex, emu-clause, emu-intro, emu-note, body) {
@@ -2930,6 +2909,12 @@ li.menu-search-result-term:before {
   padding-right: 5px;
 }
 
+@media print {
+  #menu-toggle {
+    display: none;
+  }
+}
+
 [normative-optional],
 [deprecated],
 [legacy] {
@@ -2987,230 +2972,7 @@ li.menu-search-result-term:before {
   background-color: #eee;
   box-shadow: inset 0 -1px 0 #ccc;
 }
-</style><style>@media print {
-body {
-  font-family: Arial;
-  font-size: 10pt;
-  background: #fff;
-  color: #000;
-}
-
-.title {
-  font-family: Verdana;
-}
-
-p {
-  text-align: justify;
-  text-rendering: optimizeLegibility;
-  text-wrap: pretty;
-  overflow-wrap: break-word;
-  hyphens: auto;
-  orphans: 2;
-  widows: 2;
-}
-
-h1 {
-  text-wrap: balance;
-  line-height: 1.4;
-}
-
-emu-note p,
-emu-table td p {
-  text-align: left;
-  hyphens: manual;
-  overflow: hidden;
-}
-
-emu-table td,
-emu-table th {
-  overflow-wrap: break-word;
-}
-
-emu-table table {
-  table-layout: auto;
-  width: 100%;
-}
-
-emu-figure img {
-  max-width: 100%;
-  height: auto;
-}
-
-#spec-container {
-  max-width: none;
-}
-
-#toc a[href] {
-  background: #fff;
-  padding-right: 0.5em;
-}
-#toc a[href]::after {
-  content: /* leader(dotted) */ target-counter(attr(href), page);
-  float: right;
-  padding-left: 0.5em;
-  background: #fff;
-}
-/* NOTE: hacks because Paged.js doesn't support leader() in content directives */
-#toc ol {
-  overflow-x: hidden;
-}
-#toc ol li:before {
-  float: left;
-  width: 0;
-  white-space: nowrap;
-  content: '. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . '
-    '. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . '
-    '. . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .';
-}
-
-/* skip the Introduction since it's before the first emu-clause (and therefore doesn't have a proper page number) */
-#toc > ol > li:first-child {
-  display: none;
-}
-
-#toc,
-#spec-container > emu-intro,
-#spec-container > emu-annex {
-  break-before: recto;
-  break-after: always;
-}
-
-/* according to Ecma guidelines, we're actually not supposed to break before every clause (only the first), but Paged.js fails if we do that */
-/* so instead, just break before any of the clauses that have sub-clauses */
-#spec-container > emu-clause:has(emu-clause:not([example])) {
-  break-before: always;
-}
-
-#spec-container > emu-clause:first-of-type {
-  break-before: recto;
-}
-
-emu-note,
-emu-note p,
-emu-table tr,
-emu-table th,
-emu-table td,
-emu-alg li,
-pre,
-h1 {
-  break-inside: avoid;
-}
-
-emu-table thead,
-h1,
-figcaption,
-emu-alg > ol > li:first-child {
-  break-after: avoid;
-}
-
-emu-grammar + emu-alg,
-figcaption + emu-table,
-figcaption + span[id] + emu-table,
-emu-alg > ol > li:last-child {
-  break-before: avoid;
-}
-
-a[data-print-href]::after {
-  content: ' <' attr(href) '>';
-  color: initial;
-}
-
-emu-table thead {
-  display: table-header-group;
-}
-emu-table tfoot {
-  display: table-footer-group;
-}
-
-@page {
-  size: A4;
-}
-
-@page {
-  @top-center {
-    content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgcAAAAxCAMAAAB5w/qQAAADAFBMVEX////9/f75+vv6/P76+/z9/v/Q3OPz9/v0+fzx9fn8/P/8/P3y9vrp7/Pn8vj///72+f729/oUFBnQ3OXs8fX4+PrW4ebO3eTu9vv+///e6Ozl8Pb6/P/t8vX2egHu9/nz9fno8PPR3OL4/f7o7vLj7PDf5urr8PX09vr5+v73+Pz4+v3r7/Ps9ffc5+zQ2+Dg6e0SFBjk7vT8/Pvr9frj7fL//vzm7/Lg6Ozv8/jk7fDx+fzw+Pzv9/rw9ffr8vjS4OfV4+vv8/bo7PDc5urp7vHt9fju8ffk6/Lh6/HU4OXv8/fd5en6/v/2+/7d5+7j6e3a5OnS3eXS3OPV3eIREhfO3Obv9/3l6+7n6u7M3uQWFxzW4ej1ewHb4+rT3uPi6u/g6vDR3ufZ5+33+/8UExb2+PwWFhnt+Pzs9fvq8/Xp8vTe6e7Q3uXT2+Xb4+fv9fju8/YFBw/8///S2d/Z5evY4uba5e3X5Ozs8/bm7fAGChXr9/zY4+kNDRPP3ubP3eDy8/fi6+71/f7V3ujt8PXN1drU3ebO2uLz+v7e6PDd5ezR3+gREBPY4+gLEhcQERbe6u/R3ObU3N7M3uYKCw/b6PHV2uD6eQL9//7f5uzM0tfU4enM3unm7fLP2N0jJyvg6e/Iz9YyMzfa6O7T3uU9P0LV3+NgYGLi5enQ2+nEzdTxewfS2uIQFB7o8PXY4enQ3+UCBAnz8/ReZWxTVFnZ3uOboKaJj5bzeAb3fALe7PPCw8UpLjXsewbZ6OrP3tzV19no6uvO3OnL3uDQ0NGoqKrI09ri29O/yM/x9fvI3utNUFXxkTTt8vlxcnVWWl8YHCPa29yztbkeICXL3e6ipannhiju7/Dg4eTc29Xj18jfzr2usLLjqm2SmJ7UrYLqmki8w8qEiI25ub2krLR7f4TWomxZYmbooVzov5nU3+7auJbhsoJERkzmexXW2ufo0LjdnF3bjELIys2xvMfafinzhBp0d3rdxq5tbnJmZmnxzKnVwKT8r1+4i2AcU8nxAAAmUUlEQVR42sybe1yTVRjHh8JrhJZuwsxSbGpa2eYiMi8UFZW3mgKbxhANXZQJGYmYA0Y1YyE3BcIIvESKKVCSaVhQXipNKkC6qalJF7O0svv10+8557x7tyllf1B9z/uey7tpn0/nt+f8znNeVYMHPzz4YTeDB4eFhQXhGRsEBXUfTLB+GPX4sHv37njGB7fdpjwHjw6+wE/lzfkc74cBAVSL512PnwfuEbUBAQHn+tA96EwPCepcxLj00osuwuDWi+bMuY3AmDOHcxunN67evd0Ncc45rAa8fpQYOxa9seDRsRgJaMRAlxjHiQi9+QpwM6+v4vRj3AVYI0YCGt6dcVdGBn3zPHDVXdPwaNq0aeNQAL6iWpiT44yNrZ45c+3anNhYZ05scVtZbE6sbmb1ROeWLbE5eBibk5eXs6WNOqC6Gp2y2DMxc2Zs7LD7/1c68Dsd5SHXQXcf/P2DgoL8Bd18uAz04QwfPrxHj549exDog0GDBvXs2TMQXMu5gTNgwIC+ffvS3XeYoFevXrjBEGLUTehdDEYxhixevHg6GPoQY9ZDI0euGbnmITSM8vKl5eXl+qVRKKanTHpTf31UWjpGYHLU5KlRUWlRU6dmFiRQyUyj7yWkZU7NzCwoCCnIDIkPyczMTCDYF6YmZBZkFqgiYwxltWUpGotGayguNmgrK+Oyi9ExZGfvsgCtzmAw6LRSba0EUqSUmJgYnc7gKiszGFwotTpddLZO0uFLOknSrep1QZCPELgK/gv8/p4AxDyOv5tudHOCZfoAefpFAyADziDGgw8+CAWImSfE5I/gDCFuAjcKbgfTiZEjpxAjR17jpj9ARZj05VHlen0Um+n0qDRM3dS0BNYUxFfEx+N2Rjor4itCJk4MQSFm4pftXOtcmxO5NlqKlmIkSaPVaKVkQXR0DApIzknG5zkzVZFSdnFtyoYNGzQ04dlS5d69cbteKa7VSdnZlp2VJUwIOsliKdEQWokqjVZbmwJN6CANLf0XLBY8RnfTgiEBQVd3rgOMPFH58B/owDce+IMgNx7i4FwOEBLohhh6yHBdQAoUIQLdCJXcgAABcUyaNOk+IGuEM3fuPRQkRlA86CUjR4YxjMXjx7NmMdXjFWaBCWDNmjWoqdPfjV6vV7oA9TzBsnnz2HN00REDVSLmW7sBpOiyNRuysyXLO3sr4wyxKRrMscMRB7SSTtLu3ZvscCQjPpRotXEoKSnRKSkaR2KiRWuJs1RWWizoaDW1vXx14CuKsxVC1ysCj0/3B/7+3btDAAFA/sxTI90vhRVw+4Q5CsI2oEO+QHgE9HAzawA7IIOBm7GyP+AWgG7ABm5/0APiAqgZEVTQBIYGzg+MiIgIdTP/rbfeuu6663ATc+/hZQTKxRfPveKKUICK6pvn3zwfLUwGbnIaKqcG82rZuVwyYE14Jzt754aUlOpsaTkmWWMgJC2UYNCV7HUZtBKKw4EpjytZbrEspxigYfFhJ5YV6Ebjgg7wP/jshEBT0aUo/wG/zlB04DHXSiDo5stliAd9+iAYcJfQQwHRAPQEgRxhEFANwDrRd4ACdwlYKYaNGHYP6zOfAGOAFoyRGcoIDx8fDiZw7vBgWa4AnafAPKDXvzyVkZY+m8psPUoamD37qdmz0RD8E+IpGuj1qi82WOhHj+ivk5Zv2A8OHjx4YH9bmUvSwCbgkkoqtRBJycKEqemgIjIRM+8ooaVAknKeTX/sMROudD0+07hyrjtXdbYEeA//9TWBtkZACKCbgNYFmn9fFJNAS8LwPneKWQd88gc9CBSDOACgos4IjrCFNzGYOUA1nYMB7AEzCPAFUwjqMkymXD3cYLpgUXpa+qK0tEWLMtMyF10vqIi/HmWiJ5FeJDoiE1ElOzahSdzESiIiPIpDEx2tyttg0eAXvytOO3NBW9s3x08cOnTq0InjP++vnpkd43TEFBcvKKm06GJDovfs2/rCCy9s/WRPTrzToCHtuGISar8//IKbw68vX7rv3dcY76LlF1Ufbn+O2Ue/5z7eqjx89Tk/iCGoC8OC398JQon9uN37RsQDTzwkcvmlDPgD0Occ0IODDttBcCiMgzupo7iFwNGj4RFwEwMAmgceQFR+4AFyCgJyDPcQc+dezGKFJ0PoGsV6YqvByuIxKIsXrxw/ZOXKleOp3DjeHVSoiEZmzHgUtBPkB6o8h0ajy44rKUlcsPvAz4c+/+jN98C3p478fmA3TKOltrjMsTNv4ROHm1fX2VNBYXvzu2VbVsXt2rSqIOHdk1Y8wnOivnWPKf2Y3WjMV2epbep8my0/H3WWWm3Ob295Cfv1MNUHzVnqLGOW2WizmdWtzfv8MU9BKoWu14H3YhEgc64gAHIICAjyzh34c7oDkT8AaOREAV/yL4dI0CF6n5lzPCCBQCUwA2QJRCbByx9gyGBaQzUOBfqKYIwbh07PiDdYiQjsxwsSBSiCCIYYsNSDAEMF2ATKH5TE6bAFlCorpf0HT3wGFfzY0LCioanpvW8P/balZO/evFXFLstj+06m1meZ1WqrurCosD71p+JYxINNEzus9alqeppks9nUhY1HTbmb7UVWNUG10ao2WyGKJHVSaTvmXKV6+vksqxmfFNEH6tTWd4NZLkHhv4gHPm6QbxQUfPzBZQI4BTGxPALwQMARBmE0AgC4hTPpvr4cJYeASuwT0HoyisBvHIy58EoPwq9kRiEcvfAXX5yQ+yIVwR3Lls0jj4AK5bHOeUogj3NzoQNDWVmtZNG1HTxy6qMff2xqalgBBtZ89cNHB/ZX7q2M3Z6SvrGqvrBOjamj6TW2ptZ3TIZ31G8trLearVbSQRKuwsY96embCwtp8vFlozkJlRGzblMb1Un5jS/hl/jB85AT/o4kK1Ritua37wuSfQJtHv5tHYQp/sAjfRDkmT/A3QeNQCQORNqI5ppm/dpAgmzBfZwbkDnAdC9ZsmTYiCVL3EH9Js7ixe4EwvQpU+AOZD+g0B9ccsnkS/i+L4pIS6N76tSCgoKFBVQtDAkJiefwpEF1NbIGCmsZEznURb6A11KMIJqB7IIqUqtDAkhDMsCa0NDQUDNj2wrQUFPT9Nlv+0sqXbHOlM31tiR1YV19fWp9qtVaqDa3v3S9S3+0sdRqNCZhQbDzdaF9j2npMXsSJjqfggePFEZzUVG+1ZiUVHpyB+mg1GbOLzUb84uKrEbEhaoP3DpgQvjP4oFsEyAJIQ4lFAiZ8HiA6C8HBYoEikegvpBIz0GBYDSu0aNvuQUVoBFnEuO+SZRDIBuAivIHChiMAujBJsAk9LoYZVSvYdT0Yp6AV0gtjKESfuWYcDiB8PArV4bT9oLK0Fmzhs6i6nRmPTR0OgfJSiQsyR84U7QwB9rtB4589sebX80YuGJgQ8OMGTNqtjU0DPzh1DfbKyXD9d+vtlvz1YX2db/8tHl1KqavsL4jN2VChx0qMGe1VzU24gInNy5N2JwFybSvA+1Go9FqbK1CtxFxwZaU/3GA6um3MeZU5RuT1OqsrX5+/wMdBARcwF0CLtkfKGkDGsAe+EMRbntAjtF74UeeYM6dHKQP8PTOOb3FWDz0dAm8J04NIqAa2smHEjhA4KDFM2z5I0LfCCVHMHYcvj/tDRT8Gdbcddc0KlTdLQ4T6OqHTmg/KhkZcsO+SRV9STCtH0aE6uuvtXABcft/JxnUzCAhzKhpamJRoeGHI/tdknMRJhyer65jwb1bthxdByEU2o+lO3Na7IXGosK392x8cuOTALUrJWFzqs1W2vzBjh07Pl6Xb1SbV+/bMWVH29tYNmylHd0e939/h8wHh9uxNth+Cf4v44F7XWBqUPzBGfeNQD5f8M4nBirbRwUWARANlsj09bIHI4A7CtCSITIH5AimA3G8AMRvGjXhlUZYswyWYBlVJmwv+yvo/5qlXmC1wX4B6Z+Stm+OnPhj4ApEAi+a3vutDXnGlnqr0ZraYqqQXCGmrXAKVvtJx7MLmkvVavu6R3JznBVOp5M2rJro9M12s7r0+ecoPfBxe5HZ2v6SCry/zmZU578dfIGfO4kYoHpufVGS0djir+oKziKhrOQQOp1572Y44OcLwxWQRqCsscga3OIG5oAhcge8pqh+I9yBJ7cDlj6YTlAWATM/UsC9wiWTJyckYMJwNBSl16dh3hiZmfEhnIW8iYysiBRs2pTIyeNErgUileAGz1E7cDMdSI62458dem/FCh8Z1NR8dWJ37donTtYbC9VZh69Mvj4zZOnRVjt0sM4VvwBbQKO9JcEp5WnYuYVG46kDP9WrjUa1cTXTQfB6mxo66AMdhIWxRGIAxPFLFtdBl/H3OqAexz8sDJFfJgi4GyYFBeXIkQSB0NADBkHgFQ5IDmjQgr594R/JEShnC2CEOHREQEA+kUBQWEngAAE3MZSQY0CuO5cITPMA+qiJ/uWmXGAymXCD/iimebnU4KKip4QUMn6sKS+fbZqtT1uajq+qvrBI2QbL/i8PffQVLQlewCqeOlAW+V0jFgBb0dZMwyqDIfbo6vokY2HVxoRV0IE6q+VZp+RCTpncpuSjg6ostRk6CPMLCP41n+sggGf1MUfPbe9ohTjU0EEX4ps46FwH1FVMASyCBzx3cK7wimQVcctmEdtHIL9xwJnTG86AW0cyBoovoEaGf+5mrMw4MA30owqL+FUenOc14Fxx1VUZGVjjM/q9QUzDRUSEzqeCiwqSBqPnjyZHQH9lICc0kA4arkXeATrQ4XBp95HP32uCN5gBtm3bRg3rNn37c1vkUdhEm9HcvPnYMVwtrfQrrtqYznRgb8mp0LgsneigKMkGHfj7qfqstyGPQPEA2SRaFJ7e17GulPaT6vVdqYOzjwc077fKMqBpV+JBN6LTM0daK3q4uZMxHCIYHjgocBAIRC0OHJBLnD9pEuvPZ5sGRAjaPtzH+g/IDMDd95lnnhn2DFXD7plL7YWjriSwJRDwI4dliAboYOzLi+Fe0J/w+dNixFrVF5rsXdmxB458BGs4kAEdoCawUPzw5e68o+2kAyM2hvX12B4iZ5Rka9yYu4r8QeqxZx3akjgt7T61WovDRwdqK3SAPq0LRtIB84QfbP11nbUUOUfIwLgeMhH86/4ACH/QeeYIyC8giNbLGxCByisnwhsgdUDAJJIrQCXbg5vE+QJsgTf8/QNyB9wRAF71j5rMwYB37hUsVDII1MIebBLWgIhz5DFgAgTexoBwlDBwUgQd4KWD6oOfvVkzsGFbw+k6OLG74vv20iSbsQ65IqMVOSKkjNSpVa+bVjWnwh8878xjZw3aM+kg38b9gX/w+ixZB+e++tO69vwsm8g5mrtIB8ArhazQ+brA9w2ovNRwmioQBrwY3kPB7Q0efFB0kU4UsKNGBd73eCmJMgKcMWcAuwf3/p80w72kCdCqz5h3jfCWoLy8PyQkbgXko/TgEkGUjMopGbId1QdPvQl3sO20eLDth+O7r/++tdRms9apMXVF+AXTyUBp1euLFjyPHWRpy7Nrtd46sCk6sLn9wfp8roMLgl9otJZiPbChUNqxaH03P1WX07k/wBrFefzxx8kfUBcN3WKBAN6p54t8mcMR/gDrAlb7O3vzHAKGqPhTH3qIWyC7AwG67l5oKN4eiGB+wXP3f/fdd2dkZAijcOF5510XKAObEIjMA0ooq3AjLQHmI5cArsX+hjY581GuvRZHDipntM7lMEAHNZh1rAyebFsx8NvjLB7Y1HV1ZrO90F5YaLdn2e2pjRtJB0b4gwIcV8rrgjYy95inDoqMiAfUJR3AHwQHBB+2Gm3wF0Xq1tUtJ83qJPP6bqou5Cz2jdRlI8y5GzkWeCIigz8lkQBvLgPynBJ4V42/iDQcrRe0eiA6yHi9ljQM7dx7ZNgBg/dRA72bRLVY2Ye6l30cNYTLewn36eGEWXeMnDdrAgoYT8WHO9bMu2PNHXiPie07HpoyBTqIsVRK0EHTDOSSvXWApeLbb9oq9qwuzTfW1f0qnzB3fNrx6QuuRTHNpVZzaktCfKRLq5WYDpIl0+ZCc9KZdWDN/2WQ6qXV6JizWqvWH94e3JHa1Tr4h/6ATfyZ0gi4FYQzoJrjMdG3eLBEBsaAUN4/IHyyBzAIQD5doIreTyRPEBXFwjlsAga+DiE+REH0qycCOl7I8UQ5Tli+fHl0NPb4iYkaGkoSvVyqmihJOysTD3z20XtNAxt84kFTQ8Oh3SnOJ6vqi6x19sPj9MtedGOJZ/4gtWWL05WMv0wHXJsisS50pgMz9o2DPq2nY6eTHd9hkvp8mtXlOsD9d/sFRQfyZsFnh+DLZYzT/YFHNnE03QK3LujHL15HUjKKQh50j5IZspIQ+YNZQ8kcKG8KzAIjZfqbRO7QZMLvmicPcpcBuIXZXrzsBdIGejdp+FgVIll2WpJ3n/gcWWX4RC+amr463mbJWdVcb7Qin/hQSPauuF0ulyvZFRdnqVhFR4elLffmuHQGDb3GDGWtNW3uZF2wqYuQT9zRTIfQz29nq3KfT0u7WAfcJ3aqg8cZ3vkDgsTgm20mxHPlXzGIRpgD8Y8TaNSb+JN48451KYrj+LXuH2a8a9XWxB7PfEJIEYRY8apFK2rkaYiRiD2qkodnvLSKGFF7z2eFWHmUqB2e2ju2Z8Ve4fs75/Sed2sGLz5tz7i3/ev8eu73/Ea1fpAFhOiEGpgKhCCI+g9YBzkgaMqqC/BBw/MIdE2gX+xP1LcU5MCBQOBSV864WOoT+gw/7Y9MBT6iy7AD5BVpZ1/QhhBjBog9v3xRzN5nyr2tFDHa9G5y25kr8Jo2bc9Cuz3ZesLvx8Fh7qK0ziPT0uDyHN9DUwdu/6E+cKd+yLl2uR/RyMMKoP0gNVvtIAf42X4wn49yccjDLIZMCxjJSRj9B5SkaAwzyBAD7yQTQbt2LbijgFMmC5UrQyMIZQA2M0qVasgphVFdKINvaSDCDJSOQDIB24cMPyzt1as39o6lKH7AzgFHJF5RlqIeYmkvFp0AuK0k49QXb50bzrx18u2GeWWNvLl+ZfUE++O7cB25EVJ6em/nXc6yKUE1+cHQVGfcnO2v198+KkhZOPzHzwXoRNgBDhvn9m67SBx8l63Phd/yH+BxIBefCwQQKxDQ6GUM1DBpgHcUXR5AHxgVAvkRovEF8h4AgzwYw+gu0xOJ2lBwBDb3BaASaN9z+gLEF2JI474D1hohiaCa8VITV7rwWukaRK9BqkYvTbWasYOrVqptYDA78A7eePnTrZMn38bYwbwLj8LpLsfjIye2QuJjIXFc2ASgFabP1nrvGkoZSmPPLImy6mjfzg/G+uv80A4KH1zlcdaxRUPPS5Ky0Q5+y49EqkA8DZg+gB0Y+Db2JPcDGXmM8R9IhDygFmTZAopwosmrBQimDBiL6uqQ01CGGRlt6M8OSxmIP/XAmTzQgMDjQHSsImFFp4GdBq5YUWuFwKgP+nKQ7ToSdxijkLuM/INAQNWss8KfkYdyYV5ZxBTgN8AREseHL5nh5xEULky/OxYWEAds/iTEjupsvTFCU5GlNHYTnhee1KRU+BRsNuSljey0HWeArScmIheR7CCJ/AcJCYUKr0lNcnveFb34EWcMGzLT6hAkGZOEH6lQLPgVEHcSCv1rUxBJiUIDiBmNYskrEc4DGpTu0EG4DtAQ4hTJ9IGsXjAAoRCbqBgbX2jCrjUxehKIphwMjkFeHKMSBShNSyNjsLucBLkMzH9N0KAph241FTDfBOZ0CXagqgHYweWrN5Gk+nb3hv2Qi3Ak7n924ULmi/C648dnL+7S8/TYoT43fInkUEQOku9GZ/yq0w0fPAjIQYSfOQ4rS3YwfbvPw54L+RTyJ8b5yY9UDyHmVDf5D+rthLbEl21xHLcn6WPRn9iBkp12YOKLLLxENDHUNaHJKR4YRnHA0pJoLdl6io1BniKlVgDIWNPXqbw8Q7QjWgidwJyLhm4AkL4EaqQvgcUVWBgSroEGDRc1liAhid3nHeUjS9o20GnLYaPoTEm2xpsDKF47EH5///r1txvA/v34IE/10ZXwgXX2oDd91ojB95Yg92yO3+fB2+fbuqslHjOu4ffODB3r83hsHr/fBw8T3w9stjkntim58iiv9qX642AHUGvYD5CNdro88tKG+uu4kZLG8NvciC+Y8piUb+FWYDKZ2CQb7AAexKzHAXpEVP+eM7mojjgm4k3I0kbBRE4Zjr7zw3fMkbqAMAQXuPtgLTWgEtE+liEcZCYWGwEouIAPYyHvmukg1WAQgTiDytEmMKhmQeNghkIUhlpccXlRwOIIBgcfCL/IvPnw5UnOreuPrl6aNWzwuoA5PT09Pm3k+l07lp9x2nzOTWDojVpaSqLZVStj+z44Gp22OnQVeaqjpm/3ON1+7AemfNgP3E7nvr0oUDAVXhN35oz79EQkLN9bfgaRCo7bCb9y7jw5TD+ETAHMV7LBDsh1QPEEjjHYJPcBI9UAhRiACCyTVQiMorEFwSpZiggm4VxQOUoN3bHEukUMaEb80+E5ZGlJY0C3xt16RWEVz+QxqDS9Ek84iFKJIYMGSFLBBw2GgA8FNJHD8Z0p87Uz7ABxZ0cwYseOcOXqoyf37z8E159kXj0QOB4MaVPivTAEb/LjkZNvZ5w/v5M4v/OouVkzNTHe1Xnx6/M059xFHcvtjDsZGa9ymkw5lIt3Mu7cuVPDlAOlIa9wNeNAbhSzbDt851pW9ubLlefHZgD44E/IUejn+wHIq9exfCMHov4DmdIs9AHvQEciV66qgtI8K4HnGTAvMxojTaQqoE4CtwAhXASy1IBGJaIwdwFFoy2nTtGcUgqImjXRSGpyRgN0rQUYGq4DuieuKFtgBnAlHY+EAnPPkim8z7x582bm58PpXjO0QYp1cOIgB7xHickjeo4vltYzrdiC8T2aD+qDrSZFTUns0SnrMUYbnDLahOMByJ31X4nsE06efDQSU6O3B5gMZN+RQdoB9WLN83CMsSThMJKqgTWAzVjySVVOdQ72CeMa5weNOIjrcEnA0g5aE/UtWF1wymIAKcwEUpnLlEEDYABIQ6iLwAJVM5QqKCj1d9TlYKTMKO71WtUJoUgkZE9p9nwKFOOVK1fCZ72HDqVHgg5zfPK6UGj2Fq9ro9VsdXWxdlHNiwdRdWtKH7ypwhFH1ECi1QqDQfnzYgs97Ol/iFUohH9kbvREPfw5lXpKjty4odcqYEBZasr/sQNe455LoIcYGLSwMpBU2ABzHhCsvlGKA4H+OOAqoTJEgg7LRm2FltO4QRsCWq2XBHu/iDSUpE8lufe3By2HM8bztvn3WMhp9iOQf8Bb6rcAlp+omZlnIRQJIiPhOcqczShunTss/tChQ0GHN91rXxeJzPZ6UficBUgL0RAaED3qnU1C7CcQhRIUmtAUHVa9Hk0SeJvAR/UwQEv3MCzEQJcDU/4l2ApWFab0t3Ygr8l4I0SCkdyE8V8u1aLBKqqQK7E8QEoSWpmVImEmIZKUa3B4ukGBCmgqMFnQhoOBoCJylUWyMmWtLm3LAgokAmohmsAzDng3cpQEdoHWCKyCWgnGurVkNRzlcSigmc2Jqhawz3Y4Zm3cqIWCQbuKgneH4/lGSANHJBLB3Kz+0g40ZgcdTFg7/qY1ppXFajPLoDkuAozRE+J7GOBLAN+kKW4jpZUmeGFGC/jPdaKMO0vy8dLG0gb4wyBGHwj/AatkkFUN0AcyDVG6EDCPoQmd5Us0KkFYCLT1LZaa9REkkId8jIQwgCxAHKF+NIDwtbZza20iiOL4rrkYjVFDq3U1xct6bzXi/V6p1mtHqwapIlZBBEUbZUKhoniJrhXBh0QIcdHgvpQaioqQZ+uF4Itvgn4LH/wA/s/MZDdZFcXLz905M7vbvMxJ5r9nzoxnUcGTMwRXcLqsloh7ZxVoSmbU2svowzyw3hmvBMn+UUwYHmnBK2IynHv06EHLvNH+ptyXQv7Vq7cPHr05EoafoNsb+l3RQig/ONKUmcsM8W2eUtSBFpyyNkRWJ9Cr1LVFGOp/nKLEDwEeoFNSVBkjRhR3dTyg6UaIvrn/yQ9Q94gC1c+q64MNqAtLfoRKSmjoc7UWWiGjPigICieIFMUPuzpqC52bUbZSdVCBKukAzDLADWiTC3cWs6MDZzOoT13wQg2LlEGc0r96EtAyKZwu2q1crik8D0GEcBIzx2/ftuT6m7DC6dHTXH/hS3/y1VusiIePhJ8+DQOfH/jB7wb8YG2gyLnBNYau1JhYtgaj4eVPD0AD6EUtgbx1o2gwjZzDiIY4T3BN4zrHOyY38ChDjIdxXajKtbpmCF8qGvhAwZ+PC9/nH4Coj6AKHPiJK7yYkScOlCE6ZfxArFy5TcPBIkmXQooEGUOgxQw0v9Ar6MFBIPegThWkZXqiSD9Ip3F4DCimS+QiRyrAIeQgQLbtlfQdqiN8mO654AryUK5jP5swRMIoFMDbY4/e9Cfz1x98/Pg0WcAWSJRkNA/8rh/Q70GRme0RPqE5HuI3Os3m2+03umL7x8egkkyzc1H7hoTBFrefMfiNZgZv6WznLBKLdTa3b020zuEhdmP7686AwdtinYwFX8Z1nY9vnmNEi+M+xeE7gn+mDxR+TwgKGuaZCKUPYKQ4ICAMfF5BoQNSBjfoFPrAv8y5KwakO8R+FFvqXeAlpcyEWKRqz3qZqLqjES+JgJCaQAqDq2TrZCNqHs9BwxVtGJsfgKZrOVKLb48dyYXz+VfhN2+OQBq0PDgifi6ScBOMDR6uH8yTiAqayg9arXWJtN19+nQlE0lZtmVnPnTYlmW3birYjp3aYo44C6dmK4VIgt8Ys9q1+RZu2ql9+cp+dnTMtu3uSUarbV3kMfso56xipxJ68dPYa82Q/Om+OLA+P/DaiigRCq2SwEUIN509KPRBlLZJ8khQq02BGkWcJSqCEAGeaKgNETjo9A0VVNsiJwgUWNmICx71N+svLPOxejVkADSHogPIFhmKPyAHQYIrWip//dhbxBNzTbmnuSaoA/KD/Lynb7Br2rFjD2gDLeEHeKlw6f+VH1xydrPn5epunreymz+MVp9tnrq7/HjTB3OTNbrlnrM7e69sdbDppbuMj9h2nm/avK6amhG5ZKXNZjszIZK2e3iz8349W/S112ARy6lGpvBP70b+zg/A7/kB0KUTuKJAGOUHEBBkXFHgIjdFOFO//lkaadWMkCwmIeCDOQaUYl7ykkxNwCXMOFCYx2PwmdIL52hYx5ZK3kQlSglsF1AtpQeoFIumqYUaESPUvGZsnbxOt7RtF1pacPw1R4hrQ8lYCKpu0FnAjleHDpupkmmwVGk8D/U4syLj+Xjrxd0F1SeBE1b11t1tQ3d5dqgwUl1tMtNOM2OwNGyO2PN5aGLGYq3Voeqmc+UVzDxZ3WOt4dnZ1fWM4dOhGv5SJDZ2uaqo77s3ueBf5qhw0068b3JtmQoQr4r++eV2ojE/cTsQppegkDHtnriiF+cKxA0UKwQqbtwtUDkIV9X6xquC+wMCfwrCLcUdoPZBwGXQhx0TCWr19eHA/okvLrTQjmcXmi7g8EzTL0yLRD6Oj8hdw7+WQ8kY06N8q/PYPNy00uocsOAHhVJEY5fLVqkQjVvlPqePTT2RPGVNPl7K8lnV5gnOVc5Ne8AITbIG2iqlD/CDih0ZdNYMPexwbrJsaTh7aCDCd5bXc4b3in+Qo9pAVOLLRPH7Qd08k+cHKAiVg3IReNuoqk0OWoHSBWpjNC9j1V3hvObyAsXNFfAICAJwcoWXh+jNIcyk1BSkpHii4CC4L6AavILK588Hjh9/ThxXNOSy3rrlNiXatqbwn6DEojs8yOYQ/CChh7RWZyMbHtpUSSctpgUKVlwL9paX9xwNnClZfc5yM9JdupsZ2Gvd5QPly132UJbHrQEtNMFKL/1sbWChUMqKLCov22M9wQCxwRlet9dq5oPOeoOHaIz/65z1BnQ1EngawFvHIpfBo1aPGubliaIed2MDqrmPSWg4UG+OQIkBNdijcLc+UKvbOgDiBsr8nFke/ou/j9aXEuM70pRSqXn9njlMJuU3/a5J0l8lw3hcXOw73I8XzkN9pRhHOLnT6WGVUrbVdkaZESpY03S9t7qFaaFp1jBLV5dFK1Zbl+WU2KSqlR8rOYu0xVZFmzLBGm7rKi/k2mI7r7c657IZx+7VUk6qVPiazp6zeqAPpB/8nSeEfghthuK6gFzCEFQB58bVDDI4VPOBqdKgkL8QwJWEVDRuoaQqQD2+RVBTe6iRwUGsBnLyAaqvA8BJal6x+gcO4fqA2/bx86vavEwygyPpN8lfmEImg32ZR+v+ahT77yZLXWwK/KDcw/KlrFkoZzB/k7fj+tre8nD687RpdopvL3dHP1tnAqn3Fntdnrs4Pt9JB8fZBU3fag+zcRk7PTJmd2nt5Rib+97pPWOnx8/eWbDnnCuXKp/j2qq/d4RQAypzPRhA9/vS0XzCQFVlr9a+2bBkcG4ljYeJBYEYEWSSySBOd7JZTDPLNEWhEDAsCGqR5BWEMiefUJ7peRFNoHVqwkqlsKO2adJBwX3JVQENDhgQkJ4A3DGhbnRA6UdbOLKQFkjAUOEzhDL+O91gpLvu4sMDD+9h7nswiiDhnEKnsfDEXf6pksY808jn+Nq1XflUauxlW7qbnUkvDBxNm1p7ZWD/63S2qCdOpuPBzz2aPg53jC3dpbFKq6ndKGzlZqXSfqnQyTnbPjZhUqpSGPukQcoX/40fqHllGAA3UPwk86A+llQfIJQeQX5A+l/pA9rvQCAmFeAAVMQAeh9usN2jV4KaF0i6SWEDiEV3qaJA1u7JjBRKLxCKQOpEKRTvq7TVq8ePQzQOC10IZHCpQUIq+lw0SHXAfmyAa/x3PJjbzqJhYIqAmbqGhqGbpoHOWIKpgqBpngniRTzLedacqGfZRGbuLwayTNPw1zqe1EL4AGMiy2aDQZNH28z9LBEwGWvjJhwhkMBjgaCKAfydI4QkSEJppDEpjYhKlGcEJW1t7mYH3hxCRFLzCheVr7qPdsnxwgQia5AeraUU4vZOIP5bBVmQpf2SXVy98DOR4FZVe6645tcORENL3PsGebg/fq/Wa04AAAAASUVORK5CYII=);
-  }
-}
-@page :first {
-  @top-center {
-    content: none;
-  }
-}
-
-:root {
-  --page-number-style: decimal;
-}
-
-#toc {
-  page: toc;
-}
-@page toc {
-  --page-number-style: lower-roman;
-}
-emu-intro {
-  page: intro;
-}
-@page intro {
-  --page-number-style: lower-roman;
-}
-
-#toc {
-  counter-reset: page 1;
-}
-#spec-container > emu-clause:first-of-type {
-  counter-reset: page 1;
-}
-
-@page :left {
-  @bottom-left {
-    content: counter(page, var(--page-number-style));
-  }
-}
-@page :right {
-  @bottom-right {
-    content: counter(page, var(--page-number-style));
-  }
-}
-
-@page :first {
-  @bottom-left {
-    content: '';
-  }
-  @bottom-right {
-    content: '';
-  }
-}
-
-}</style><style>
-    @media print {
-      @page :left {
-        @bottom-right {
-          content: '© Ecma International 2024';
-        }
-      }
-      @page :right {
-        @bottom-left {
-          content: '© Ecma International 2024';
-        }
-      }
-      @page :first {
-        @bottom-left {
-          content: '';
-        }
-        @bottom-right {
-          content: '';
-        }
-      }
-      @page :blank {
-        @bottom-left {
-          content: '';
-        }
-        @bottom-right {
-          content: '';
-        }
-      }
-    }
-    </style></head><body><div id="shortcuts-help">
+</style></head><body><div id="shortcuts-help">
 <ul>
   <li><span>Toggle shortcuts help</span><code>?</code></li>
   <li><span>Toggle "can call user code" annotations</span><code>u</code></li>
@@ -3218,10 +2980,10 @@ emu-intro {
   <li><span>Jump to search box</span><code>/</code></li>
   <li><span>Toggle pinning of the current clause</span><code>p</code></li>
   <li><span>Jump to <i>n</i>th pin</span><code>1-9</code></li>
-</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120" width="54" height="54">
+</ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
-    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins<button class="unpin-all">clear</button></div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">+</span><a href="#messageformat-objects" title="MessageFormat Objects"><span class="secnum">1</span> MessageFormat Objects</a><ol class="toc"><li><span class="item-toggle">+</span><a href="#sec-intl-messageformat-constructor" title="The Intl.MessageFormat Constructor"><span class="secnum">1.1</span> The Intl.MessageFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat" title="Intl.MessageFormat ( source, [ locales [ , options ] ] )"><span class="secnum">1.1.1</span> Intl.MessageFormat ( <var>source</var>, [ <var>locales</var> [ , <var>options</var> ] ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-initializemessageformat" title="InitializeMessageFormat ( messageFormat, source, locales, options )"><span class="secnum">1.1.2</span> InitializeMessageFormat ( <var>messageFormat</var>, <var>source</var>, <var>locales</var>, <var>options</var> )</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-properties-of-intl-messageformat-constructor" title="Properties of the Intl.MessageFormat Constructor"><span class="secnum">1.2</span> Properties of the Intl.MessageFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype" title="Intl.MessageFormat.prototype"><span class="secnum">1.2.1</span> Intl.MessageFormat.prototype</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat-internal-slots" title="Internal slots"><span class="secnum">1.2.2</span> Internal slots</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-properties-of-intl-messageformat-prototype-object" title="Properties of the Intl.MessageFormat Prototype Object"><span class="secnum">1.3</span> Properties of the Intl.MessageFormat Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype.constructor" title="Intl.MessageFormat.prototype.constructor"><span class="secnum">1.3.1</span> Intl.MessageFormat.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype-tostringtag" title="Intl.MessageFormat.prototype [ @@toStringTag ]"><span class="secnum">1.3.2</span> Intl.MessageFormat.prototype [ @@toStringTag ]</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype.format" title="Intl.MessageFormat.prototype.format ( [ values [ , onError ] ] )"><span class="secnum">1.3.3</span> Intl.MessageFormat.prototype.format ( [ <var>values</var> [ , <var>onError</var> ] ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype.formatToParts" title="Intl.MessageFormat.prototype.formatToParts ( [ values [ , onError ] ] )"><span class="secnum">1.3.4</span> Intl.MessageFormat.prototype.formatToParts ( [ <var>values</var> [ , <var>onError</var> ] ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype.resolvedoptions" title="Intl.MessageFormat.prototype.resolvedOptions ( )"><span class="secnum">1.3.5</span> Intl.MessageFormat.prototype.resolvedOptions ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-properties-of-intl-messageformat-instances" title="Properties of Intl.MessageFormat Instances"><span class="secnum">1.4</span> Properties of Intl.MessageFormat Instances</a></li><li><span class="item-toggle">+</span><a href="#sec-intl-messageformat-abstracts" title="Abstract Operations for MessageFormat Objects"><span class="secnum">1.5</span> Abstract Operations for MessageFormat Objects</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-getmessagedata" title="GetMessageData ( source )"><span class="secnum">1.5.1</span> GetMessageData ( <var>source</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-handledatetimeinput" title="HandleDateTimeInput ( input, opts )"><span class="secnum">1.5.2</span> HandleDateTimeInput ( <var>input</var>, <var>opts</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-datetimemessagevalue" title="
+    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins<button class="unpin-all">clear</button></div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">+</span><a href="#messageformat-objects" title="MessageFormat Objects"><span class="secnum">1</span> MessageFormat Objects</a><ol class="toc"><li><span class="item-toggle">+</span><a href="#sec-intl-messageformat-constructor" title="The Intl.MessageFormat Constructor"><span class="secnum">1.1</span> The Intl.MessageFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat" title="Intl.MessageFormat ( locales, source [ , options ] )"><span class="secnum">1.1.1</span> Intl.MessageFormat ( <var>locales</var>, <var>source</var> [ , <var>options</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-initializemessageformat" title="InitializeMessageFormat ( messageFormat, locales, source, options )"><span class="secnum">1.1.2</span> InitializeMessageFormat ( <var>messageFormat</var>, <var>locales</var>, <var>source</var>, <var>options</var> )</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-properties-of-intl-messageformat-constructor" title="Properties of the Intl.MessageFormat Constructor"><span class="secnum">1.2</span> Properties of the Intl.MessageFormat Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype" title="Intl.MessageFormat.prototype"><span class="secnum">1.2.1</span> Intl.MessageFormat.prototype</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat-internal-slots" title="Internal slots"><span class="secnum">1.2.2</span> Internal slots</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-properties-of-intl-messageformat-prototype-object" title="Properties of the Intl.MessageFormat Prototype Object"><span class="secnum">1.3</span> Properties of the Intl.MessageFormat Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype.constructor" title="Intl.MessageFormat.prototype.constructor"><span class="secnum">1.3.1</span> Intl.MessageFormat.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype-tostringtag" title="Intl.MessageFormat.prototype [ @@toStringTag ]"><span class="secnum">1.3.2</span> Intl.MessageFormat.prototype [ @@toStringTag ]</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype.format" title="Intl.MessageFormat.prototype.format ( [ values [ , onError ] ] )"><span class="secnum">1.3.3</span> Intl.MessageFormat.prototype.format ( [ <var>values</var> [ , <var>onError</var> ] ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype.formatToParts" title="Intl.MessageFormat.prototype.formatToParts ( [ values [ , onError ] ] )"><span class="secnum">1.3.4</span> Intl.MessageFormat.prototype.formatToParts ( [ <var>values</var> [ , <var>onError</var> ] ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-intl.messageformat.prototype.resolvedoptions" title="Intl.MessageFormat.prototype.resolvedOptions ( )"><span class="secnum">1.3.5</span> Intl.MessageFormat.prototype.resolvedOptions ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-properties-of-intl-messageformat-instances" title="Properties of Intl.MessageFormat Instances"><span class="secnum">1.4</span> Properties of Intl.MessageFormat Instances</a></li><li><span class="item-toggle">+</span><a href="#sec-intl-messageformat-abstracts" title="Abstract Operations for MessageFormat Objects"><span class="secnum">1.5</span> Abstract Operations for MessageFormat Objects</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-getmessagedata" title="GetMessageData ( source )"><span class="secnum">1.5.1</span> GetMessageData ( <var>source</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-handledatetimeinput" title="HandleDateTimeInput ( input, opts )"><span class="secnum">1.5.2</span> HandleDateTimeInput ( <var>input</var>, <var>opts</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-datetimemessagevalue" title="
         DateTimeMessageValue (
           value: a Date object,
           opts: an Object,
@@ -3233,7 +2995,7 @@ emu-intro {
           <var>opts</var>: an Object,
           <var>funcCtx</var>: an Object,
         ): an ECMAScript value
-      </a></li><li><span class="item-toggle">+</span><a href="#sec-getmessagefunctions" title="GetMessageFunctions ( userFunctions )"><span class="secnum">1.5.4</span> GetMessageFunctions ( <var>userFunctions</var> )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-messageformat-numberfunctions" title="MessageFormat Number Functions"><span class="secnum">1.5.4.1</span> MessageFormat Number Functions</a></li><li><span class="item-toggle-none"></span><a href="#sec-messageformat-stringfunctions" title="MessageFormat String Functions"><span class="secnum">1.5.4.2</span> MessageFormat String Functions</a></li><li><span class="item-toggle-none"></span><a href="#sec-messageformat-datetimefunctions" title="MessageFormat DateTime Functions"><span class="secnum">1.5.4.3</span> MessageFormat DateTime Functions</a></li><li><span class="item-toggle-none"></span><a href="#sec-messageformat-datefunctions" title="MessageFormat Date Functions"><span class="secnum">1.5.4.4</span> MessageFormat Date Functions</a></li><li><span class="item-toggle-none"></span><a href="#sec-messageformat-timefunctions" title="MessageFormat Time Functions"><span class="secnum">1.5.4.5</span> MessageFormat Time Functions</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-createmessageformatcontext" title="CreateMessageFormatContext ( mf, values, onError )"><span class="secnum">1.5.5</span> CreateMessageFormatContext ( <var>mf</var>, <var>values</var>, <var>onError</var> )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-messagecontextrecord" title="MessageFormatContext Records"><span class="secnum">1.5.5.1</span> MessageFormatContext Records</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-resolvemessage" title="ResolveMessage ( ctx )"><span class="secnum">1.5.6</span> ResolveMessage ( <var>ctx</var> )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-selectpattern" title="SelectPattern ( ctx )"><span class="secnum">1.5.6.1</span> SelectPattern ( <var>ctx</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-selectvariant" title="SelectVariant ( ctx, selectors, variants )"><span class="secnum">1.5.6.2</span> SelectVariant ( <var>ctx</var>, <var>selectors</var>, <var>variants</var> )</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-resolveexpression" title="ResolveExpression ( ctx, expression )"><span class="secnum">1.5.7</span> ResolveExpression ( <var>ctx</var>, <var>expression</var> )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-resolvefunction" title="ResolveFunction ( ctx, source, resArg, annotation )"><span class="secnum">1.5.7.1</span> ResolveFunction ( <var>ctx</var>, <var>source</var>, <var>resArg</var>, <var>annotation</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-resolveunknown" title="ResolveUnknown ( source, value )"><span class="secnum">1.5.7.2</span> ResolveUnknown ( <var>source</var>, <var>value</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-formatmarkuppart" title="FormatMarkupPart ( ctx, markup )"><span class="secnum">1.5.8</span> FormatMarkupPart ( <var>ctx</var>, <var>markup</var> )</a></li><li><span class="item-toggle">+</span><a href="#sec-getsource" title="GetSource ( ctx, value )"><span class="secnum">1.5.9</span> GetSource ( <var>ctx</var>, <var>value</var> )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-messagevaluesource" title="MessageValueSource ( mv )"><span class="secnum">1.5.9.1</span> MessageValueSource ( <var>mv</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-handlemessageformaterror" title="HandleMessageFormatError ( ctx, completionRecord )"><span class="secnum">1.5.10</span> HandleMessageFormatError ( <var>ctx</var>, <var>completionRecord</var> )</a></li><li><span class="item-toggle">+</span><a href="#sec-resolvefallback" title="ResolveFallback ( source )"><span class="secnum">1.5.11</span> ResolveFallback ( <var>source</var> )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-messagefallbackpart" title="MessageFallbackPart ( source )"><span class="secnum">1.5.11.1</span> MessageFallbackPart ( <var>source</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-messagefallbackstring" title="MessageFallbackString ( source )"><span class="secnum">1.5.11.2</span> MessageFallbackString ( <var>source</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-resolvevalue" title="ResolveValue ( ctx, value )"><span class="secnum">1.5.12</span> ResolveValue ( <var>ctx</var>, <var>value</var> )</a></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Stage 1 Draft / May 3, 2024</h1><h1 class="title">Intl.MessageFormat</h1>
+      </a></li><li><span class="item-toggle">+</span><a href="#sec-getmessagefunctions" title="GetMessageFunctions ( userFunctions )"><span class="secnum">1.5.4</span> GetMessageFunctions ( <var>userFunctions</var> )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-messageformat-numberfunctions" title="MessageFormat Number Functions"><span class="secnum">1.5.4.1</span> MessageFormat Number Functions</a></li><li><span class="item-toggle-none"></span><a href="#sec-messageformat-stringfunctions" title="MessageFormat String Functions"><span class="secnum">1.5.4.2</span> MessageFormat String Functions</a></li><li><span class="item-toggle-none"></span><a href="#sec-messageformat-datetimefunctions" title="MessageFormat DateTime Functions"><span class="secnum">1.5.4.3</span> MessageFormat DateTime Functions</a></li><li><span class="item-toggle-none"></span><a href="#sec-messageformat-datefunctions" title="MessageFormat Date Functions"><span class="secnum">1.5.4.4</span> MessageFormat Date Functions</a></li><li><span class="item-toggle-none"></span><a href="#sec-messageformat-timefunctions" title="MessageFormat Time Functions"><span class="secnum">1.5.4.5</span> MessageFormat Time Functions</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-createmessageformatcontext" title="CreateMessageFormatContext ( mf, values, onError )"><span class="secnum">1.5.5</span> CreateMessageFormatContext ( <var>mf</var>, <var>values</var>, <var>onError</var> )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-messagecontextrecord" title="MessageFormatContext Records"><span class="secnum">1.5.5.1</span> MessageFormatContext Records</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-resolvemessage" title="ResolveMessage ( ctx )"><span class="secnum">1.5.6</span> ResolveMessage ( <var>ctx</var> )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-selectpattern" title="SelectPattern ( ctx )"><span class="secnum">1.5.6.1</span> SelectPattern ( <var>ctx</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-selectvariant" title="SelectVariant ( ctx, selectors, variants )"><span class="secnum">1.5.6.2</span> SelectVariant ( <var>ctx</var>, <var>selectors</var>, <var>variants</var> )</a></li></ol></li><li><span class="item-toggle">+</span><a href="#sec-resolveexpression" title="ResolveExpression ( ctx, expression )"><span class="secnum">1.5.7</span> ResolveExpression ( <var>ctx</var>, <var>expression</var> )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-resolvefunction" title="ResolveFunction ( ctx, source, resArg, annotation )"><span class="secnum">1.5.7.1</span> ResolveFunction ( <var>ctx</var>, <var>source</var>, <var>resArg</var>, <var>annotation</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-resolveunknown" title="ResolveUnknown ( source, value )"><span class="secnum">1.5.7.2</span> ResolveUnknown ( <var>source</var>, <var>value</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-formatmarkuppart" title="FormatMarkupPart ( ctx, markup )"><span class="secnum">1.5.8</span> FormatMarkupPart ( <var>ctx</var>, <var>markup</var> )</a></li><li><span class="item-toggle">+</span><a href="#sec-getsource" title="GetSource ( ctx, value )"><span class="secnum">1.5.9</span> GetSource ( <var>ctx</var>, <var>value</var> )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-messagevaluesource" title="MessageValueSource ( mv )"><span class="secnum">1.5.9.1</span> MessageValueSource ( <var>mv</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-handlemessageformaterror" title="HandleMessageFormatError ( ctx, completionRecord )"><span class="secnum">1.5.10</span> HandleMessageFormatError ( <var>ctx</var>, <var>completionRecord</var> )</a></li><li><span class="item-toggle">+</span><a href="#sec-resolvefallback" title="ResolveFallback ( source )"><span class="secnum">1.5.11</span> ResolveFallback ( <var>source</var> )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-messagefallbackpart" title="MessageFallbackPart ( source )"><span class="secnum">1.5.11.1</span> MessageFallbackPart ( <var>source</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-messagefallbackstring" title="MessageFallbackString ( source )"><span class="secnum">1.5.11.2</span> MessageFallbackString ( <var>source</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-resolvevalue" title="ResolveValue ( ctx, value )"><span class="secnum">1.5.12</span> ResolveValue ( <var>ctx</var>, <var>value</var> )</a></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Stage 1 Draft / May 6, 2024</h1><h1 class="title">Intl.MessageFormat</h1>
 
 <emu-clause id="messageformat-objects">
   <h1><span class="secnum">1</span> MessageFormat Objects</h1>
@@ -3245,33 +3007,33 @@ emu-intro {
       The MessageFormat constructor is the <dfn tabindex="-1">%MessageFormat%</dfn> intrinsic object
       and a standard built-in property of the Intl object.
       Behaviour common to all service constructor properties of the Intl object
-      is specified in <a href="https://tc39.es/ecma402/#sec-internal-slots" data-print-href="">9.1</a>.
+      is specified in <a href="https://tc39.es/ecma402/#sec-internal-slots">9.1</a>.
     </p>
 
     <emu-clause id="sec-intl.messageformat">
-      <h1><span class="secnum">1.1.1</span> Intl.MessageFormat ( <var>source</var>, [ <var>locales</var> [ , <var>options</var> ] ] )</h1>
+      <h1><span class="secnum">1.1.1</span> Intl.MessageFormat ( <var>locales</var>, <var>source</var> [ , <var>options</var> ] )</h1>
 
       <p>
         When the <code>Intl.MessageFormat</code> function is called with arguments
-        <var>source</var>, <var>locales</var>, and <var>options</var>, the following steps are taken:
+        <var>locales</var>, <var>source</var>, and <var>options</var>, the following steps are taken:
       </p>
 
       <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>messageFormat</var> be ?&nbsp;OrdinaryCreateFromConstructor(NewTarget, <emu-xref href="#sec-properties-of-intl-messageformat-prototype-object" id="_ref_7"><a href="#sec-properties-of-intl-messageformat-prototype-object">%MessageFormat.prototype%</a></emu-xref>,
-           « <var class="field">[[InitializedMessageFormat]]</var>, <var class="field">[[LocaleMatcher]]</var>, <var class="field">[[MessageData]]</var>, <var class="field">[[RequestedLocales]]</var>, <var class="field">[[Runtime]]</var> »).</li><li>Return ?&nbsp;<emu-xref aoid="InitializeMessageFormat" id="_ref_8"><a href="#sec-initializemessageformat">InitializeMessageFormat</a></emu-xref>(<var>messageFormat</var>, <var>source</var>, <var>locales</var>, <var>options</var>).</li></ol></emu-alg>
+           « <var class="field">[[InitializedMessageFormat]]</var>, <var class="field">[[LocaleMatcher]]</var>, <var class="field">[[MessageData]]</var>, <var class="field">[[RequestedLocales]]</var>, <var class="field">[[Runtime]]</var>&nbsp;»).</li><li>Return ?&nbsp;<emu-xref aoid="InitializeMessageFormat" id="_ref_8"><a href="#sec-initializemessageformat">InitializeMessageFormat</a></emu-xref>(<var>messageFormat</var>, <var>locales</var>, <var>source</var>, <var>options</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-initializemessageformat" aoid="InitializeMessageFormat">
-      <h1><span class="secnum">1.1.2</span> InitializeMessageFormat ( <var>messageFormat</var>, <var>source</var>, <var>locales</var>, <var>options</var> )</h1>
+      <h1><span class="secnum">1.1.2</span> InitializeMessageFormat ( <var>messageFormat</var>, <var>locales</var>, <var>source</var>, <var>options</var> )</h1>
 
       <p>
         The abstract operation InitializeMessageFormat accepts the arguments
-        <var>messageFormat</var> (which must be an object), <var>source</var>, <var>locales</var>, and <var>options</var>.
+        <var>messageFormat</var> (which must be an object), <var>locales</var>, <var>source</var>, and <var>options</var>.
         It initializes <var>messageFormat</var> as a MessageFormat object.
         The following steps are taken:
       </p>
 
-      <emu-alg><ol><li>If <var>source</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>msgData</var> be ?&nbsp;<emu-xref aoid="GetMessageData" id="_ref_9"><a href="#sec-getmessagedata">GetMessageData</a></emu-xref>(<var>source</var>).</li><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>Set <var>options</var> to ?&nbsp;GetOptionsObject(<var>options</var>).</li><li>Let <var>matcher</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>,
-           « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val> », <emu-val>"best fit"</emu-val>).</li><li>Let <var>userFunctions</var> be ?&nbsp;Get(<var>options</var>, <emu-val>"functions"</emu-val>).</li><li>Let <var>functions</var> be ?&nbsp;<emu-xref aoid="GetMessageFunctions" id="_ref_10"><a href="#sec-getmessagefunctions">GetMessageFunctions</a></emu-xref>(<var>userFunctions</var>).</li><li>Set <var>messageFormat</var>.<var class="field">[[MessageData]]</var> to <var>msgData</var>.</li><li>Set <var>messageFormat</var>.<var class="field">[[RequestedLocales]]</var> to <var>requestedLocales</var>.</li><li>Set <var>messageFormat</var>.<var class="field">[[LocaleMatcher]]</var> to <var>matcher</var>.</li><li>Set <var>messageFormat</var>.<var class="field">[[Functions]]</var> to <var>functions</var>.</li><li>Return <var>messageFormat</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>requestedLocales</var> be ?&nbsp;CanonicalizeLocaleList(<var>locales</var>).</li><li>If <var>source</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>msgData</var> be ?&nbsp;<emu-xref aoid="GetMessageData" id="_ref_9"><a href="#sec-getmessagedata">GetMessageData</a></emu-xref>(<var>source</var>).</li><li>Set <var>options</var> to ?&nbsp;GetOptionsObject(<var>options</var>).</li><li>Let <var>matcher</var> be ?&nbsp;GetOption(<var>options</var>, <emu-val>"localeMatcher"</emu-val>, <emu-const>string</emu-const>,
+           « <emu-val>"lookup"</emu-val>, <emu-val>"best fit"</emu-val>&nbsp;», <emu-val>"best fit"</emu-val>).</li><li>Let <var>userFunctions</var> be ?&nbsp;Get(<var>options</var>, <emu-val>"functions"</emu-val>).</li><li>Let <var>functions</var> be ?&nbsp;<emu-xref aoid="GetMessageFunctions" id="_ref_10"><a href="#sec-getmessagefunctions">GetMessageFunctions</a></emu-xref>(<var>userFunctions</var>).</li><li>Set <var>messageFormat</var>.<var class="field">[[MessageData]]</var> to <var>msgData</var>.</li><li>Set <var>messageFormat</var>.<var class="field">[[RequestedLocales]]</var> to <var>requestedLocales</var>.</li><li>Set <var>messageFormat</var>.<var class="field">[[LocaleMatcher]]</var> to <var>matcher</var>.</li><li>Set <var>messageFormat</var>.<var class="field">[[Functions]]</var> to <var>functions</var>.</li><li>Return <var>messageFormat</var>.</li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 
@@ -3421,7 +3183,7 @@ emu-intro {
       </li>
       <li>
         <var class="field">[[MessageData]]</var> is an Object conforming to the
-        <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json" data-print-href="">JSON Schema definition</a>
+        <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json">JSON Schema definition</a>
         of the Unicode MessageFormat 2.0 specification.
       </li>
       <li>
@@ -3438,10 +3200,10 @@ emu-intro {
 
     <emu-clause id="sec-getmessagedata" type="implementation-defined abstract operation" aoid="GetMessageData">
       <h1><span class="secnum">1.5.1</span> GetMessageData ( <var>source</var> )</h1>
-      <p>The implementation-defined abstract operation GetMessageData takes argument <var>source</var> (a String or an Object) and returns an Object conforming to the <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json" data-print-href="">JSON Schema definition</a> of a message according to the Unicode MessageFormat 2.0 specification.</p>
+      <p>The implementation-defined abstract operation GetMessageData takes argument <var>source</var> (a String or an Object) and returns an Object conforming to the <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json">JSON Schema definition</a> of a message according to the Unicode MessageFormat 2.0 specification.</p>
           <p>
             If <var>source</var> is a String, it returns the message data representation corresponding to the input <var>source</var> according to the
-            <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/syntax.md" data-print-href="">Unicode MessageFormat 2.0 syntax</a>.
+            <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/syntax.md">Unicode MessageFormat 2.0 syntax</a>.
             If <var>source</var> is an Object, it checks that <var>source</var> holds a valid message data representation,
             and returns an equivalent Object that is not affected by any further changes to <var>source</var>.
           </p>
@@ -3616,7 +3378,7 @@ emu-intro {
         <h1><span class="secnum">1.5.6.1</span> SelectPattern ( <var>ctx</var> )</h1>
         <p>The abstract operation SelectPattern takes argument <var>ctx</var> (a <emu-xref href="#messageformatcontext-record" id="_ref_33"><a href="#messageformatcontext-record">MessageFormatContext Record</a></emu-xref>) and returns a List of Strings and Objects with an internal slot <var class="field">[[MessageValue]]</var>. It selects the pattern to format from the message data model. It performs the following steps when called:</p>
 
-        <emu-alg><ol><li>Let <var>msgData</var> be <var>ctx</var>.<var class="field">[[MessageFormat]]</var>.<var class="field">[[MessageData]]</var>.</li><li>Let <var>msgType</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"type"</emu-val>).</li><li>If <var>msgType</var> is <emu-val>"message"</emu-val>, then<ol><li>Let <var>pattern</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"pattern"</emu-val>).</li></ol></li><li>Else,<ol><li>Assert: <var>msgType</var> is <emu-val>"select"</emu-val>.</li><li>Let <var>selectorsData</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"selectors"</emu-val>).</li><li>Let <var>selectorExpressions</var> be ?&nbsp;CreateListFromArrayLike(<var>selectorsData</var>, « Object »).</li><li>Let <var>selectors</var> be an empty List.</li><li>For each element <var>selExp</var> of <var>selectorExpressions</var>,<ol><li>Let <var>sel</var> be <emu-xref aoid="ResolveExpression" id="_ref_34"><a href="#sec-resolveexpression">ResolveExpression</a></emu-xref>(<var>ctx</var>, <var>selExp</var>).</li><li>Let <var>selectKey</var> be ?&nbsp;Get(<var>sel</var>.<var class="field">[[MessageValue]]</var>, <emu-val>"selectKey"</emu-val>).</li><li>If IsCallable(<var>selectKey</var>) is <emu-val>true</emu-val>, then<ol><li>Append <var>sel</var>.<var class="field">[[MessageValue]]</var> to <var>selectors</var>.</li></ol></li><li>Else,<ol><li>Let <var>error</var> be ThrowCompletion(<emu-val>TypeError</emu-val>).</li><li>Perform ?&nbsp;<emu-xref aoid="HandleMessageFormatError" id="_ref_35"><a href="#sec-handlemessageformaterror">HandleMessageFormatError</a></emu-xref>(<var>ctx</var>, <var>error</var>).</li><li>Append <emu-val>null</emu-val> to <var>selectors</var>.</li></ol></li></ol></li><li>Let <var>variantsArray</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"variants"</emu-val>).</li><li>Let <var>variants</var> be ?&nbsp;CreateListFromArrayLike(<var>variantsArray</var>, « Object »).</li><li>Let <var>selectedVariant</var> be ?&nbsp;<emu-xref aoid="SelectVariant" id="_ref_36"><a href="#sec-selectvariant">SelectVariant</a></emu-xref>(<var>ctx</var>, <var>selectors</var>, <var>variants</var>).</li></ol></li><li>Return ?&nbsp;CreateListFromArrayLike(<var>pattern</var>, « String, Object »).</li></ol></emu-alg>
+        <emu-alg><ol><li>Let <var>msgData</var> be <var>ctx</var>.<var class="field">[[MessageFormat]]</var>.<var class="field">[[MessageData]]</var>.</li><li>Let <var>msgType</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"type"</emu-val>).</li><li>If <var>msgType</var> is <emu-val>"message"</emu-val>, then<ol><li>Let <var>pattern</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"pattern"</emu-val>).</li></ol></li><li>Else,<ol><li>Assert: <var>msgType</var> is <emu-val>"select"</emu-val>.</li><li>Let <var>selectorsData</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"selectors"</emu-val>).</li><li>Let <var>selectorExpressions</var> be ?&nbsp;CreateListFromArrayLike(<var>selectorsData</var>, « Object&nbsp;»).</li><li>Let <var>selectors</var> be an empty List.</li><li>For each element <var>selExp</var> of <var>selectorExpressions</var>,<ol><li>Let <var>sel</var> be <emu-xref aoid="ResolveExpression" id="_ref_34"><a href="#sec-resolveexpression">ResolveExpression</a></emu-xref>(<var>ctx</var>, <var>selExp</var>).</li><li>Let <var>selectKey</var> be ?&nbsp;Get(<var>sel</var>.<var class="field">[[MessageValue]]</var>, <emu-val>"selectKey"</emu-val>).</li><li>If IsCallable(<var>selectKey</var>) is <emu-val>true</emu-val>, then<ol><li>Append <var>sel</var>.<var class="field">[[MessageValue]]</var> to <var>selectors</var>.</li></ol></li><li>Else,<ol><li>Let <var>error</var> be ThrowCompletion(<emu-val>TypeError</emu-val>).</li><li>Perform ?&nbsp;<emu-xref aoid="HandleMessageFormatError" id="_ref_35"><a href="#sec-handlemessageformaterror">HandleMessageFormatError</a></emu-xref>(<var>ctx</var>, <var>error</var>).</li><li>Append <emu-val>null</emu-val> to <var>selectors</var>.</li></ol></li></ol></li><li>Let <var>variantsArray</var> be ?&nbsp;Get(<var>msgData</var>, <emu-val>"variants"</emu-val>).</li><li>Let <var>variants</var> be ?&nbsp;CreateListFromArrayLike(<var>variantsArray</var>, « Object&nbsp;»).</li><li>Let <var>selectedVariant</var> be ?&nbsp;<emu-xref aoid="SelectVariant" id="_ref_36"><a href="#sec-selectvariant">SelectVariant</a></emu-xref>(<var>ctx</var>, <var>selectors</var>, <var>variants</var>).</li></ol></li><li>Return ?&nbsp;CreateListFromArrayLike(<var>pattern</var>, « String, Object&nbsp;»).</li></ol></emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-selectvariant" type="implementation-defined abstract operation" aoid="SelectVariant">
@@ -3625,7 +3387,7 @@ emu-intro {
             <p>
               It applies the variant selection method defined by
               the "Resolve Preferences", "Filter Variants", and "Sort Variants" steps of the
-              <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/formatting.md#pattern-selection" data-print-href="">Pattern Selection</a>
+              <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/formatting.md#pattern-selection">Pattern Selection</a>
               section of the Unicode MessageFormat 2.0 specification.
             </p>
 
@@ -3638,7 +3400,7 @@ emu-intro {
 
             <p>
               The value returned by this operation must be an Object matching the JSON Schema definition of a message pattern:
-              <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json#/$defs/pattern" data-print-href="">
+              <a href="https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json#/$defs/pattern">
                 https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json#/$defs/pattern
               </a>.
             </p>
@@ -3696,7 +3458,7 @@ emu-intro {
       <h1><span class="secnum">1.5.10</span> HandleMessageFormatError ( <var>ctx</var>, <var>completionRecord</var> )</h1>
       <p>The abstract operation HandleMessageFormatError takes arguments <var>ctx</var> (a <emu-xref href="#messageformatcontext-record" id="_ref_62"><a href="#messageformatcontext-record">MessageFormatContext Record</a></emu-xref>) and <var>completionRecord</var> (a Completion Record). It handles errors during formatting. It performs the following steps when called:</p>
 
-      <emu-alg><ol><li>Assert: <var>completionRecord</var> is a Completion Record.</li><li>Assert: <var>completionRecord</var> is an abrupt completion.</li><li>Let <var>onError</var> be <var>ctx</var>.<var class="field">[[OnError]]</var>.</li><li>Let <var>error</var> be <var>completionRecord</var>.<var class="field">[[Value]]</var>.</li><li>If <var>onError</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform ?&nbsp;Call(<var>onError</var>, <emu-val>undefined</emu-val>, « <var>error</var> »).</li></ol></li><li>Else if an appropriate notification mechanism exists, then<ol><li>Issue a warning for <var>error</var>.</li></ol></li></ol></emu-alg>
+      <emu-alg><ol><li>Assert: <var>completionRecord</var> is a Completion Record.</li><li>Assert: <var>completionRecord</var> is an abrupt completion.</li><li>Let <var>onError</var> be <var>ctx</var>.<var class="field">[[OnError]]</var>.</li><li>Let <var>error</var> be <var>completionRecord</var>.<var class="field">[[Value]]</var>.</li><li>If <var>onError</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform ?&nbsp;Call(<var>onError</var>, <emu-val>undefined</emu-val>, « <var>error</var>&nbsp;»).</li></ol></li><li>Else if an appropriate notification mechanism exists, then<ol><li>Issue a warning for <var>error</var>.</li></ol></li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-resolvefallback" type="abstract operation" aoid="ResolveFallback">

--- a/spec.emu
+++ b/spec.emu
@@ -23,35 +23,35 @@ contributors: Eemeli Aro
     </p>
 
     <emu-clause id="sec-intl.messageformat">
-      <h1>Intl.MessageFormat ( _source_, [ _locales_ [ , _options_ ] ] )</h1>
+      <h1>Intl.MessageFormat ( _locales_, _source_ [ , _options_ ] )</h1>
 
       <p>
         When the `Intl.MessageFormat` function is called with arguments
-        _source_, _locales_, and _options_, the following steps are taken:
+        _locales_, _source_, and _options_, the following steps are taken:
       </p>
 
       <emu-alg>
         1. If NewTarget is *undefined*, throw a *TypeError* exception.
         1. Let _messageFormat_ be ? OrdinaryCreateFromConstructor(NewTarget, %MessageFormat.prototype%,
            &laquo; [[InitializedMessageFormat]], [[LocaleMatcher]], [[MessageData]], [[RequestedLocales]], [[Runtime]] &raquo;).
-        1. Return ? InitializeMessageFormat(_messageFormat_, _source_, _locales_, _options_).
+        1. Return ? InitializeMessageFormat(_messageFormat_, _locales_, _source_, _options_).
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-initializemessageformat" aoid="InitializeMessageFormat">
-      <h1>InitializeMessageFormat ( _messageFormat_, _source_, _locales_, _options_ )</h1>
+      <h1>InitializeMessageFormat ( _messageFormat_, _locales_, _source_, _options_ )</h1>
 
       <p>
         The abstract operation InitializeMessageFormat accepts the arguments
-        _messageFormat_ (which must be an object), _source_, _locales_, and _options_.
+        _messageFormat_ (which must be an object), _locales_, _source_, and _options_.
         It initializes _messageFormat_ as a MessageFormat object.
         The following steps are taken:
       </p>
 
       <emu-alg>
+        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. If _source_ is *undefined*, throw a *TypeError* exception.
         1. Let _msgData_ be ? GetMessageData(_source_).
-        1. Let _requestedLocales_ be ? CanonicalizeLocaleList(_locales_).
         1. Set _options_ to ? GetOptionsObject(_options_).
         1. Let _matcher_ be ? GetOption(_options_, *"localeMatcher"*, ~string~,
            &laquo; *"lookup"*, *"best fit"* &raquo;, *"best fit"*).


### PR DESCRIPTION
Fixes #32

Switches the first two constructor arguments around, so they're `(locales, source, options)` rather than `(source, locales, options)`.